### PR TITLE
chore: dependabot.ymlを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+version: 2
+updates:
+  # npm(pnpm)の依存関係
+  - package-ecosystem: 'npm' # pnpmでもnpmと書く
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 21
+    open-pull-requests-limit: 2
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    labels:
+      - 'dependencies'
+      - 'automated'
+    allow:
+      - dependency-type: 'all'
+    assignees:
+      - 'Riku10145'
+
+  # GitHub Actionsの依存関係
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 21
+    open-pull-requests-limit: 1
+    groups:
+      all-actions:
+        patterns:
+          - '*'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    labels:
+      - 'automated'
+      - 'dependencies'
+    allow:
+      - dependency-type: 'all'
+    assignees:
+      - 'Riku10145'


### PR DESCRIPTION
## Summary

- `.github/dependabot.yml` を追加
- npm(pnpm) と GitHub Actions の依存関係を週次で自動更新
- `cooldown: default-days: 21` で新リリースから21日後にPR作成
- `groups` で依存関係をまとめてPR数を削減
- コミットメッセージのプレフィックスを `chore` に統一
- assignee を `Riku10145` に設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/riku10145/nonda/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
