### PR TITLE
feat: lefthookの導入とpre-commitフックの設定

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+## プロジェクト概要
+
+薬服用記録アプリ「nonda」のモノレポ。pnpm workspacesで管理。
+
+```
+apps/web   - Next.js 16 (App Router) フロントエンド
+apps/api   - Hono バックエンド (port 8080)
+packages/types - 共通型定義（未実装）
+```
+
+## よく使うコマンド
+
+```bash
+# 依存インストール
+pnpm install
+
+# 開発サーバー
+pnpm --filter web dev   # localhost:3000
+pnpm --filter api dev   # localhost:8080
+
+# Lint / Format (web)
+pnpm --filter web lint:oxlint   # oxlint
+pnpm --filter web fmt           # oxfmt (自動修正)
+pnpm --filter web fmt:check     # oxfmt (チェックのみ)
+
+# Lint / Format (api)
+pnpm --filter api lint:oxlint   # oxlint
+pnpm --filter api fmt           # oxfmt (自動修正)
+pnpm --filter api fmt:check     # oxfmt (チェックのみ)
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # nonda
+
 シンプルな薬服用記録アプリ
+
+## 構成
+
+```
+nonda/
+├── apps/
+│   ├── web/   # フロントエンド (Next.js)
+│   └── api/   # バックエンド (Hono)
+└── packages/
+    └── types/ # 共通型定義
+```
+
+## 技術スタック
+
+| | 技術 |
+|---|---|
+| フロントエンド | Next.js 16 (App Router), TypeScript, Tailwind CSS v4 |
+| バックエンド | Hono, TypeScript, Node.js |
+| パッケージ管理 | pnpm |
+| Linter | oxlint |
+| Formatter | oxfmt |
+| Git hooks | lefthook |
+
+## セットアップ
+
+```bash
+pnpm install
+```
+
+## 開発
+
+```bash
+# web (localhost:3000)
+pnpm --filter web dev
+
+# api (localhost:8080)
+pnpm --filter api dev
+```

--- a/apps/api/.oxfmtrc.json
+++ b/apps/api/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": []
+}

--- a/apps/api/.oxlintrc.json
+++ b/apps/api/.oxlintrc.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript", "import"],
+  "env": {
+    "node": true,
+    "es2022": true
+  },
+  "rules": {}
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,10 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "lint:oxlint": "oxlint src",
+    "fmt": "oxfmt .",
+    "fmt:check": "oxfmt --check ."
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",
@@ -17,6 +20,8 @@
   },
   "devDependencies": {
     "@types/node": "^25",
+    "oxfmt": "^0.47.0",
+    "oxlint": "^1.62.0",
     "tsx": "^4.19.3",
     "typescript": "^5"
   }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,7 +11,13 @@ pre-commit:
       glob: "*.{js,ts,jsx,tsx}"
       run: pnpm lint:oxlint {staged_files}
 
+    - name: api-fmt
+      root: apps/api
+      glob: "*.{js,ts}"
+      run: pnpm fmt {staged_files}
+      stage_fixed: true
+
     - name: api-lint
       root: apps/api
       glob: "*.{js,ts}"
-      run: pnpm lint {staged_files}
+      run: pnpm lint:oxlint {staged_files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+pre-commit:
+  jobs:
+    - name: web-fmt
+      root: apps/web
+      glob: "*.{js,ts,jsx,tsx,css}"
+      run: pnpm fmt {staged_files}
+      stage_fixed: true
+
+    - name: web-lint
+      root: apps/web
+      glob: "*.{js,ts,jsx,tsx}"
+      run: pnpm lint:oxlint {staged_files}
+
+    - name: api-lint
+      root: apps/api
+      glob: "*.{js,ts}"
+      run: pnpm lint {staged_files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,21 +3,21 @@ pre-commit:
     - name: web-fmt
       root: apps/web
       glob: "*.{js,ts,jsx,tsx,css}"
-      run: pnpm fmt {staged_files}
+      run: pnpm exec oxfmt {staged_files}
       stage_fixed: true
 
     - name: web-lint
       root: apps/web
       glob: "*.{js,ts,jsx,tsx}"
-      run: pnpm lint:oxlint {staged_files}
+      run: pnpm exec oxlint {staged_files}
 
     - name: api-fmt
       root: apps/api
       glob: "*.{js,ts}"
-      run: pnpm fmt {staged_files}
+      run: pnpm exec oxfmt {staged_files}
       stage_fixed: true
 
     - name: api-lint
       root: apps/api
       glob: "*.{js,ts}"
-      run: pnpm lint:oxlint {staged_files}
+      run: pnpm exec oxlint {staged_files}

--- a/package.json
+++ b/package.json
@@ -9,5 +9,11 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@10.33.2",
+  "pnpm": {
+    "onlyBuiltDependencies": ["lefthook"]
+  },
+  "devDependencies": {
+    "lefthook": "^2.1.6"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,12 @@ importers:
       '@types/node':
         specifier: ^25
         version: 25.6.0
+      oxfmt:
+        specifier: ^0.47.0
+        version: 0.47.0
+      oxlint:
+        specifier: ^1.62.0
+        version: 1.62.0
       tsx:
         specifier: ^4.19.3
         version: 4.21.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      lefthook:
+        specifier: ^2.1.6
+        version: 2.1.6
 
   apps/api:
     dependencies:
@@ -1869,6 +1873,60 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  lefthook-darwin-arm64@2.1.6:
+    resolution: {integrity: sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.6:
+    resolution: {integrity: sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.6:
+    resolution: {integrity: sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.6:
+    resolution: {integrity: sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.6:
+    resolution: {integrity: sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.6:
+    resolution: {integrity: sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.6:
+    resolution: {integrity: sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.6:
+    resolution: {integrity: sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.6:
+    resolution: {integrity: sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.6:
+    resolution: {integrity: sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.6:
+    resolution: {integrity: sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==}
+    hasBin: true
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -4153,6 +4211,49 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  lefthook-darwin-arm64@2.1.6:
+    optional: true
+
+  lefthook-darwin-x64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.6:
+    optional: true
+
+  lefthook-linux-arm64@2.1.6:
+    optional: true
+
+  lefthook-linux-x64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.6:
+    optional: true
+
+  lefthook-windows-arm64@2.1.6:
+    optional: true
+
+  lefthook-windows-x64@2.1.6:
+    optional: true
+
+  lefthook@2.1.6:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.6
+      lefthook-darwin-x64: 2.1.6
+      lefthook-freebsd-arm64: 2.1.6
+      lefthook-freebsd-x64: 2.1.6
+      lefthook-linux-arm64: 2.1.6
+      lefthook-linux-x64: 2.1.6
+      lefthook-openbsd-arm64: 2.1.6
+      lefthook-openbsd-x64: 2.1.6
+      lefthook-windows-arm64: 2.1.6
+      lefthook-windows-x64: 2.1.6
 
   levn@0.4.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,5 @@ packages:
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver
+onlyBuiltDependencies:
+  - lefthook


### PR DESCRIPTION
## Summary

- lefthookをルートのdevDependenciesに追加
- pnpmのpostinstallが正しく動くよう`onlyBuiltDependencies`を`pnpm-workspace.yaml`と`package.json`両方に設定
- `lefthook.yml`にpre-commitフックを定義:
  - `web-fmt`: `apps/web`のJS/TS/CSSファイルをoxfmtでフォーマット（自動ステージング）
  - `web-lint`: `apps/web`のJS/TSファイルをoxlintでlint
  - `api-lint`: `apps/api`のJS/TSファイルをeslintでlint

## Test plan

- [ ] `pnpm install`後に`.git/hooks/pre-commit`が生成されることを確認
- [ ] `apps/web`のファイルをステージしてコミットすると`web-fmt`・`web-lint`が走ることを確認
- [ ] `apps/api`のファイルをステージしてコミットすると`api-lint`が走ることを確認
- [ ] lintエラーがある状態でコミットするとブロックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/riku10145/nonda/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
