### PR TITLE
ci(api): apiパッケージもlint/fmtチェックの対象に追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,12 @@ permissions: {}
 
 jobs:
   oxlint:
-    name: Lint
+    name: Lint (${{ matrix.package }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [web, api]
     steps:
       - uses: actions/checkout@v4
 
@@ -24,11 +28,15 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Run oxlint
-        run: pnpm --filter web lint:oxlint:github
+        run: pnpm --filter ${{ matrix.package }} lint:oxlint:github
 
   oxfmt:
-    name: Format
+    name: Format (${{ matrix.package }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [web, api]
     steps:
       - uses: actions/checkout@v4
 
@@ -42,4 +50,4 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Check formatting
-        run: pnpm --filter web fmt:check
+        run: pnpm --filter ${{ matrix.package }} fmt:check

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,6 +9,7 @@
     "start": "node dist/index.js",
     "lint": "eslint src",
     "lint:oxlint": "oxlint src",
+    "lint:oxlint:github": "oxlint --format=github src",
     "fmt": "oxfmt .",
     "fmt:check": "oxfmt --check .",
     "db:generate": "drizzle-kit generate",


### PR DESCRIPTION
CIワークフローでwebのみが対象だったため、apiにも同じ品質チェックを
適用するようmatrix戦略を導入。apiのlint:oxlint:githubスクリプトも追加。

Closes #14
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/riku10145/nonda/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
