### PR TITLE
feat(ci): main マージで dev 環境に自動デプロイする CI を追加

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,58 @@
+name: Deploy API (dev)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/api/**'
+      - '.github/workflows/deploy-api.yml'
+      - 'pnpm-lock.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-api-dev
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: dev
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - uses: dopplerhq/cli-action@v3
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run DB migrations (drizzle-kit migrate)
+        working-directory: apps/api
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_DEV }}
+        run: doppler run -- pnpm db:migrate
+
+      - name: Deploy to Cloudflare Workers (dev)
+        working-directory: apps/api
+        run: pnpm exec wrangler deploy --env dev
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Sync Doppler secrets to Cloudflare Worker
+        working-directory: apps/api
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_DEV }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          doppler secrets download --no-file --format json \
+            | jq 'del(.DOPPLER_PROJECT, .DOPPLER_CONFIG, .DOPPLER_ENVIRONMENT)' \
+            | pnpm exec wrangler secret bulk --env dev

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .vite/
+
+# Claude
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,6 @@ pnpm install
 pnpm --filter web dev   # localhost:3000
 pnpm --filter api dev   # localhost:8787 (doppler run -- wrangler dev / Doppler CLI が必要)
 
-# デプロイ
-pnpm --filter api deploy   # wrangler deploy
-
 # Lint / Format (web)
 pnpm --filter web lint:oxlint   # oxlint
 pnpm --filter web fmt           # oxfmt (自動修正)

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "scripts": {
     "dev": "doppler run -- wrangler dev",
-    "deploy": "wrangler deploy",
     "lint": "eslint src",
     "lint:oxlint": "oxlint src",
     "lint:oxlint:github": "oxlint --format=github src",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,9 +9,21 @@ type Bindings = {
   FRONTEND_URL: string;
 };
 
+const REQUIRED_ENV_KEYS = ["DATABASE_URL", "FRONTEND_URL"] as const satisfies ReadonlyArray<
+  keyof Bindings
+>;
+
 const app = new Hono<{ Bindings: Bindings }>();
 
 app.use("*", logger());
+app.use("*", async (c, next) => {
+  const missing = REQUIRED_ENV_KEYS.filter((key) => !c.env[key]);
+  if (missing.length > 0) {
+    console.error(`Missing required env vars: ${missing.join(", ")}`);
+    return c.json({ error: { code: "INTERNAL_ERROR", message: "Server misconfigured" } }, 500);
+  }
+  await next();
+});
 app.use(trimTrailingSlash());
 app.use("/api/*", (c, next) =>
   cors({

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -6,9 +6,17 @@
   "vars": {
     // FRONTEND_URL / DATABASE_URL の source of truth は Doppler。
     // ローカルは `doppler run -- wrangler dev` で注入される。
-    // 本番デプロイ時は Doppler の Cloudflare Workers Integration、
-    // もしくは CI で `wrangler secret put` 経由で Cloudflare 側に sync する想定。
+    // デプロイ時は GitHub Actions が `doppler secrets download | wrangler secret bulk`
+    // で Doppler dev config の値を worker secrets として流し込む。
     // ここの値は wrangler dev のフォールバック用。
     "FRONTEND_URL": "http://localhost:3000",
+  },
+  "env": {
+    "dev": {
+      "name": "nonda-api-dev",
+      // dev デプロイ後の secrets は GitHub Actions の sync ステップで
+      // Doppler dev config から push される。
+      // ここに vars を置くと Doppler との二重管理になるため空にする。
+    },
   },
 }

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -3,14 +3,6 @@
   "name": "nonda-api",
   "main": "src/index.ts",
   "compatibility_date": "2026-05-01",
-  "vars": {
-    // FRONTEND_URL / DATABASE_URL の source of truth は Doppler。
-    // ローカルは `doppler run -- wrangler dev` で注入される。
-    // デプロイ時は GitHub Actions が `doppler secrets download | wrangler secret bulk`
-    // で Doppler dev config の値を worker secrets として流し込む。
-    // ここの値は wrangler dev のフォールバック用。
-    "FRONTEND_URL": "http://localhost:3000",
-  },
   "env": {
     "dev": {
       "name": "nonda-api-dev",


### PR DESCRIPTION
## Summary
- `apps/api/wrangler.jsonc` に `[env.dev]` を追加し worker 名 `nonda-api-dev` を定義
- `.github/workflows/deploy-api.yml` を新規作成し、main push 時に **DB マイグレーション → `wrangler deploy --env dev` → Doppler→Cloudflare の secrets sync** を順に実行
- 手動 deploy は廃止し CI 一元管理（`apps/api` の `deploy` スクリプトを削除）

## 事前に必要な設定

### GitHub Environment `dev` の secrets
- `CLOUDFLARE_API_TOKEN` (Edit Cloudflare Workers テンプレートで発行)
- `CLOUDFLARE_ACCOUNT_ID`
- `DOPPLER_TOKEN_DEV` (Doppler `nonda` project / `dev` config の Service Token)

### 外部サービス
- Doppler `nonda` project / `dev` config に `DATABASE_URL` `FRONTEND_URL` を投入済み
- Cloudflare Workers サブドメイン `nonda.workers.dev` 取得済み
- Vercel プロジェクト作成済み（main → Production デプロイ）

## 注意
- 初回 main マージは worker が無い状態で `wrangler secret bulk` を走らせると失敗するため、ワークフローは **deploy → secret sync の順** にしている
- 初回デプロイ直後の数秒は secrets が無い状態なので、API リクエストが一時的にエラーになる可能性あり

## Test plan
- [ ] PR では `Deploy API (dev)` ワークフローが起動しないこと（`paths` フィルタの確認）
- [ ] 既存 `CI` (lint/fmt) が通ること
- [ ] main マージ後、migrate → deploy → secrets sync が順に成功すること
- [ ] `curl https://nonda-api-dev.nonda.workers.dev/` で API レスポンスが返ること
- [ ] Vercel から API への疎通（CORS含む）が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/riku10145/nonda/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->