### PR TITLE
feat(api): POST /api/v1/medicines を実装

### DIFF
--- a/apps/api/bruno/bruno.json
+++ b/apps/api/bruno/bruno.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "name": "nonda-api",
+  "type": "collection",
+  "ignore": ["node_modules", ".git"]
+}

--- a/apps/api/bruno/environments/local.bru
+++ b/apps/api/bruno/environments/local.bru
@@ -1,0 +1,4 @@
+vars {
+  baseUrl: http://localhost:8787
+  devUserId: 87d8b9c6-00e8-42aa-ae8c-7d0e83aa2fb7
+}

--- a/apps/api/bruno/medicines/Create medicine.bru
+++ b/apps/api/bruno/medicines/Create medicine.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Create medicine
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/v1/medicines
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-user-id: {{devUserId}}
+}
+
+body:json {
+  {
+    "name": "ロキソニン",
+    "timings": ["morning", "evening"]
+  }
+}
+
+tests {
+  test("status is 201", function() {
+    expect(res.getStatus()).to.equal(201);
+  });
+  test("returns id", function() {
+    expect(res.getBody().id).to.be.a("string");
+  });
+  test("timings match", function() {
+    expect(res.getBody().timings).to.eql(["morning", "evening"]);
+  });
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,15 +4,15 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "doppler run -- wrangler dev",
+    "dev": "doppler run -- sh -c 'wrangler dev --var DATABASE_URL:$DATABASE_URL --var FRONTEND_URL:http://localhost:3000'",
     "lint": "eslint src",
     "lint:oxlint": "oxlint src",
     "lint:oxlint:github": "oxlint --format=github src",
     "fmt": "oxfmt .",
     "fmt:check": "oxfmt --check .",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "drizzle-kit migrate",
-    "db:studio": "drizzle-kit studio"
+    "db:migrate": "doppler run -- drizzle-kit migrate",
+    "db:studio": "doppler run -- drizzle-kit studio"
   },
   "dependencies": {
     "@hono/standard-validator": "^0.2.2",

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,5 +1,14 @@
 import { Hono } from "hono";
 
-export const routes = new Hono();
+import { medicinesRoute } from "./medicines.js";
+
+type Bindings = {
+  DATABASE_URL: string;
+  FRONTEND_URL: string;
+};
+
+export const routes = new Hono<{ Bindings: Bindings }>();
 
 routes.get("/", (c) => c.json({ message: "nonda API" }));
+
+routes.route("/v1/medicines", medicinesRoute);

--- a/apps/api/src/routes/medicines.ts
+++ b/apps/api/src/routes/medicines.ts
@@ -28,6 +28,7 @@ const CreateMedicineSchema = v.object({
 export const medicinesRoute = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 // 認証スタブ: x-user-id ヘッダで userId を受け取る。本番では Auth.js セッション検証に差し替える。
+//Todo: ブラウザから叩く前に index.ts の CORS allowHeaders に x-user-id を追加する（現状は Bruno など非ブラウザのみ動作）
 medicinesRoute.use("*", async (c, next) => {
   const userId = c.req.header("x-user-id");
   if (!userId || !UUID_REGEX.test(userId)) {

--- a/apps/api/src/routes/medicines.ts
+++ b/apps/api/src/routes/medicines.ts
@@ -1,5 +1,4 @@
 import { sValidator } from "@hono/standard-validator";
-import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import * as v from "valibot";
 
@@ -46,13 +45,16 @@ medicinesRoute.post("/", sValidator("json", CreateMedicineSchema), async (c) => 
   const uniqueTimings = [...new Set(body.timings)];
   const medicineId = crypto.randomUUID();
 
-  await db.batch([
-    db.insert(medicines).values({
-      id: medicineId,
-      userId,
-      name: body.name,
-      photoUrl: body.photo_url ?? null,
-    }),
+  const [[inserted]] = await db.batch([
+    db
+      .insert(medicines)
+      .values({
+        id: medicineId,
+        userId,
+        name: body.name,
+        photoUrl: body.photo_url ?? null,
+      })
+      .returning(),
     db.insert(medicineTimings).values(
       uniqueTimings.map((timing) => ({
         medicineId,
@@ -61,15 +63,13 @@ medicinesRoute.post("/", sValidator("json", CreateMedicineSchema), async (c) => 
     ),
   ]);
 
-  const [created] = await db.select().from(medicines).where(eq(medicines.id, medicineId));
-
   return c.json(
     {
-      id: created.id,
-      name: created.name,
+      id: inserted.id,
+      name: inserted.name,
       timings: uniqueTimings,
-      photo_url: created.photoUrl,
-      created_at: created.createdAt,
+      photo_url: inserted.photoUrl,
+      created_at: inserted.createdAt,
     },
     201,
   );

--- a/apps/api/src/routes/medicines.ts
+++ b/apps/api/src/routes/medicines.ts
@@ -1,0 +1,75 @@
+import { sValidator } from "@hono/standard-validator";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import * as v from "valibot";
+
+import { createDb } from "../db/client.js";
+import { medicines, medicineTimings } from "../db/schema.js";
+
+type Bindings = {
+  DATABASE_URL: string;
+};
+
+type Variables = {
+  userId: string;
+};
+//Todo: 汎用的な定数はここで良いのか検討する
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+//Todo: スキーマの定義はこのファイル内で良いか
+const TimingSchema = v.picklist(["morning", "afternoon", "evening"]);
+
+const CreateMedicineSchema = v.object({
+  //Todo: nameの最大長は255だと無駄かなと思う。もっと短くても良いかも
+  name: v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(255)),
+  timings: v.pipe(v.array(TimingSchema), v.minLength(1)),
+  photo_url: v.optional(v.pipe(v.string(), v.url())),
+});
+
+export const medicinesRoute = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+// 認証スタブ: x-user-id ヘッダで userId を受け取る。本番では Auth.js セッション検証に差し替える。
+medicinesRoute.use("*", async (c, next) => {
+  const userId = c.req.header("x-user-id");
+  if (!userId || !UUID_REGEX.test(userId)) {
+    return c.json({ error: { code: "UNAUTHORIZED", message: "ログインが必要です" } }, 401);
+  }
+  c.set("userId", userId);
+  await next();
+});
+
+medicinesRoute.post("/", sValidator("json", CreateMedicineSchema), async (c) => {
+  const userId = c.get("userId");
+  const body = c.req.valid("json");
+  const db = createDb(c.env.DATABASE_URL);
+
+  const uniqueTimings = [...new Set(body.timings)];
+  const medicineId = crypto.randomUUID();
+
+  await db.batch([
+    db.insert(medicines).values({
+      id: medicineId,
+      userId,
+      name: body.name,
+      photoUrl: body.photo_url ?? null,
+    }),
+    db.insert(medicineTimings).values(
+      uniqueTimings.map((timing) => ({
+        medicineId,
+        timing,
+      })),
+    ),
+  ]);
+
+  const [created] = await db.select().from(medicines).where(eq(medicines.id, medicineId));
+
+  return c.json(
+    {
+      id: created.id,
+      name: created.name,
+      timings: uniqueTimings,
+      photo_url: created.photoUrl,
+      created_at: created.createdAt,
+    },
+    201,
+  );
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.33.2",
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild", "lefthook"]
+    "onlyBuiltDependencies": ["esbuild", "lefthook", "workerd"]
   },
   "devDependencies": {
     "lefthook": "^2.1.6"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ ignoredBuiltDependencies:
   - unrs-resolver
 onlyBuiltDependencies:
   - lefthook
+  - workerd


### PR DESCRIPTION
## Summary

- 薬の作成エンドポイント `POST /api/v1/medicines` を実装。`medicines` と `medicine_timings` を `db.batch` でアトミックに作成。
- 認証は後続課題のため `x-user-id` ヘッダから userId を受け取るスタブを採用（将来 Auth.js セッション検証へ差し替え）。
- 手元動作確認用に Bruno コレクション (`apps/api/bruno/`) を同梱。
- ローカル開発時の env 注入を見直し: `db:migrate` / `db:studio` を doppler 経由に変更、`dev` は `doppler run -- sh -c '... --var KEY:\$VALUE ...'` で wrangler のバインディングに直接渡す形にして `.dev.vars` を使わない運用に統一。

## Test plan

- [ ] `pnpm --filter api dev` で起動し、Bruno の `Create medicine` を Send → 201 + テスト3つ pass
- [ ] `x-user-id` 無し → 401 / UUID 形式不正 → 401
- [ ] バリデーション: `timings: []` → 400
- [ ] Drizzle Studio で `medicines` と `medicine_timings` に対応行が入っていること
- [ ] `pnpm --filter api lint:oxlint` / `fmt:check` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/riku10145/nonda/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->