### PR TITLE
docs: CLAUDE.md を整理し apps/api/CLAUDE.md を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,31 +2,26 @@
 
 ## プロジェクト概要
 
-薬服用記録アプリ「nonda」のモノレポ。pnpm workspacesで管理。
+薬服用記録アプリ「nonda」のモノレポ。pnpm workspaces で管理。
 
 ```
-apps/web   - Next.js 16 (App Router) フロントエンド
-apps/api   - Hono バックエンド (Cloudflare Workers / wrangler dev は 8787)
-packages/types - 共通型定義（未実装）
+apps/web        - Next.js 16 (App Router) フロントエンド (→ apps/web/CLAUDE.md)
+apps/api        - Hono / Cloudflare Workers バックエンド (→ apps/api/CLAUDE.md)
+packages/types  - 共通型定義
 ```
 
-## よく使うコマンド
+各アプリの開発コマンド・規約は各 `CLAUDE.md` を参照。
+
+## ルートで使うコマンド
 
 ```bash
-# 依存インストール
-pnpm install
-
-# 開発サーバー
-pnpm --filter web dev   # localhost:3000
-pnpm --filter api dev   # localhost:8787 (doppler run -- wrangler dev / Doppler CLI が必要)
-
-# Lint / Format (web)
-pnpm --filter web lint:oxlint   # oxlint
-pnpm --filter web fmt           # oxfmt (自動修正)
-pnpm --filter web fmt:check     # oxfmt (チェックのみ)
-
-# Lint / Format (api)
-pnpm --filter api lint:oxlint   # oxlint
-pnpm --filter api fmt           # oxfmt (自動修正)
-pnpm --filter api fmt:check     # oxfmt (チェックのみ)
+pnpm install                # 依存インストール
+pnpm --filter web dev       # web 開発サーバー (localhost:3000)
+pnpm --filter api dev       # api 開発サーバー (localhost:8787)
 ```
+
+## 共通コード規約
+
+- **オブジェクト形は `interface`**、ユニオン / エイリアスのみ `type`。
+- **private / モジュール内共有のシンボルは `_` プレフィックス**（例: `_shared.ts`）。外部 export しない。
+- **GitHub 操作は `gh` CLI** を優先（PR・Issue・チェック等）。

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -1,0 +1,58 @@
+# apps/api
+
+Hono + Cloudflare Workers のバックエンドAPI。
+
+## ディレクトリ構成方針
+
+### トップレベル（関心ごとに分割）
+
+```
+src/
+  index.ts        - Hono エントリ
+  routes/         - HTTP ハンドラ (薄く保ち、検証と業務ロジックは下位層へ委譲)
+  schemas/        - 入出力スキーマ (valibot) ※未分離
+  services/       - 業務ロジック / DB アクセス ※未分離
+  db/             - Drizzle スキーマとクライアント (schema.ts, client.ts)
+  utils/          - 横断ユーティリティ (jst.ts など) 
+  types/          - 共通型 ※未分離
+drizzle/          - 生成済みマイグレーション SQL
+bruno/            - Bruno API クライアント定義
+```
+
+### 命名・ファイル分割規約
+
+- **1 概念 = 1 ファイル / 1 ディレクトリ**。ファイル名は概念名そのもの（例: `create.ts`, `list.ts`）。
+- **機能ごとにディレクトリ化**して `index.ts` で barrel re-export（例: `routes/medicines/{create,list,index}.ts`）。
+- **テストは共置**し、`<name>.test.ts` で実装ファイルの隣に置く。優先度は `services/` のユニット > `schemas/` のユニット > `routes/` の統合（`app.request()` で 1 エンドポイント 1〜2 ケース）。
+- **private / モジュール内共有のヘルパーは `_` プレフィックス**（例: `_shared.ts`）。外部 export しない。
+- ルートは検証 → サービス呼び出し → レスポンス整形のみ。SQL や複雑な分岐はサービス層に置く。
+
+## 開発
+
+```bash
+pnpm dev          # localhost:8787 (doppler run -- wrangler dev / Doppler CLI 必須)
+pnpm lint:oxlint  # Lint
+pnpm fmt          # Format (自動修正)
+pnpm fmt:check    # Format チェックのみ
+```
+
+## DB / マイグレーション
+
+```bash
+pnpm db:generate  # schema.ts から SQL を生成
+pnpm db:migrate   # 本番/Neon に適用 (doppler 経由で DATABASE_URL を注入)
+pnpm db:studio    # Drizzle Studio
+```
+
+- スキーマ変更時は `db:generate` → `drizzle/` の差分を確認 → コミット → `db:migrate`。
+- 直接 SQL を書かず、`src/db/schema.ts` を起点にする。
+
+## コード規約
+
+共通規約はルートの `CLAUDE.md` を参照。以下は API 固有。
+
+- **`services/` の公開関数と `schemas/` の公開型には JSDoc** を書く（`@param` / `@returns`）。`routes/` のハンドラや `_` プレフィックスの内部関数には不要。
+
+## ドメイン規約
+
+- リクエスト / レスポンス検証は valibot + `@hono/standard-validator` を使い、ハンドラに直接書かず `schemas/` に分離する。

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -13,7 +13,7 @@ src/
   schemas/        - 入出力スキーマ (valibot) ※未分離
   services/       - 業務ロジック / DB アクセス ※未分離
   db/             - Drizzle スキーマとクライアント (schema.ts, client.ts)
-  utils/          - 横断ユーティリティ (jst.ts など) 
+  utils/          - 横断ユーティリティ (jst.ts など)
   types/          - 共通型 ※未分離
 drizzle/          - 生成済みマイグレーション SQL
 bruno/            - Bruno API クライアント定義

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,7 +2,7 @@ pre-commit:
   jobs:
     - name: web-fmt
       root: apps/web
-      glob: "*.{js,ts,jsx,tsx,css}"
+      glob: "*.{js,ts,jsx,tsx,css,md}"
       run: pnpm exec oxfmt {staged_files}
       stage_fixed: true
 
@@ -13,7 +13,7 @@ pre-commit:
 
     - name: api-fmt
       root: apps/api
-      glob: "*.{js,ts}"
+      glob: "*.{js,ts,md}"
       run: pnpm exec oxfmt {staged_files}
       stage_fixed: true
 


### PR DESCRIPTION
## Summary
- ルートの `CLAUDE.md` をモノレポ概要・横断コマンド・共通コード規約に絞る
- `apps/api/CLAUDE.md` を新設し、[valibot](https://github.com/open-circle/valibot) を参考にディレクトリ構成方針・命名規約・コード規約・ドメイン規約を整理
- 共通規約（`interface` 優先、`_` プレフィックス、`gh` CLI 優先）はルートに集約し、API 固有規約（JSDoc 対象、JST、検証分離）は `apps/api` に残す

## Test plan
- [ ] `CLAUDE.md` のリンクが正しく解決されること
- [ ] `apps/api/CLAUDE.md` の方針が現状コードとのギャップを正しく示していること
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/riku10145/nonda/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->