### PR TITLE
feat(api): バリデーションエラーを統一フォーマット (422) に揃える

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@hono/standard-validator": "^0.2.2",
     "@neondatabase/serverless": "^1.1.0",
+    "@standard-schema/spec": "^1.1.0",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.7.7",
     "valibot": "^1.0.0"

--- a/apps/api/src/routes/medicines/create.ts
+++ b/apps/api/src/routes/medicines/create.ts
@@ -1,14 +1,14 @@
-import { sValidator } from "@hono/standard-validator";
 import { Hono } from "hono";
 
 import { createDbClient } from "../../db/client.js";
 import { CreateMedicineSchema } from "../../schemas/medicines/index.js";
 import { createMedicine } from "../../services/medicines/index.js";
 import type { AppEnv } from "../../types/index.js";
+import { validator } from "../../utils/validator.js";
 
 export const createMedicineRoute = new Hono<AppEnv>().post(
   "/",
-  sValidator("json", CreateMedicineSchema),
+  validator("json", CreateMedicineSchema),
   async (c) => {
     const userId = c.get("userId");
     const body = c.req.valid("json");

--- a/apps/api/src/routes/medicines/get.ts
+++ b/apps/api/src/routes/medicines/get.ts
@@ -1,14 +1,14 @@
-import { sValidator } from "@hono/standard-validator";
 import { Hono } from "hono";
 
 import { createDbClient } from "../../db/client.js";
 import { GetMedicineParamSchema } from "../../schemas/medicines/index.js";
 import { getMedicineById } from "../../services/medicines/index.js";
 import type { AppEnv } from "../../types/index.js";
+import { validator } from "../../utils/validator.js";
 
 export const getMedicineRoute = new Hono<AppEnv>().get(
   "/:id",
-  sValidator("param", GetMedicineParamSchema),
+  validator("param", GetMedicineParamSchema),
   async (c) => {
     const userId = c.get("userId");
     const { id: medicineId } = c.req.valid("param");

--- a/apps/api/src/routes/medicines/list.ts
+++ b/apps/api/src/routes/medicines/list.ts
@@ -1,14 +1,14 @@
-import { sValidator } from "@hono/standard-validator";
 import { Hono } from "hono";
 
 import { createDbClient } from "../../db/client.js";
 import { ListMedicinesQuerySchema } from "../../schemas/medicines/index.js";
 import { listMedicines, listMedicinesWithTodayLogs } from "../../services/medicines/index.js";
 import type { AppEnv } from "../../types/index.js";
+import { validator } from "../../utils/validator.js";
 
 export const listMedicinesRoute = new Hono<AppEnv>().get(
   "/",
-  sValidator("query", ListMedicinesQuerySchema),
+  validator("query", ListMedicinesQuerySchema),
   async (c) => {
     const userId = c.get("userId");
     const { today } = c.req.valid("query");

--- a/apps/api/src/utils/validator.ts
+++ b/apps/api/src/utils/validator.ts
@@ -1,0 +1,34 @@
+import { sValidator } from "@hono/standard-validator";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type { ValidationTargets } from "hono";
+
+const _formatField = (path: StandardSchemaV1.Issue["path"]): string | undefined => {
+  if (!path || path.length === 0) return undefined;
+  return path.map((segment) => (typeof segment === "object" ? segment.key : segment)).join(".");
+};
+
+/**
+ * sValidator のラッパー。バリデーション失敗時に統一エラーフォーマット
+ * (`{ error: { code, message, details } }`) で 422 を返す。
+ */
+export const validator = <Schema extends StandardSchemaV1, Target extends keyof ValidationTargets>(
+  target: Target,
+  schema: Schema,
+) =>
+  sValidator(target, schema, (result, c) => {
+    if (!result.success) {
+      return c.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "入力値が不正です",
+            details: result.error.map((issue) => ({
+              field: _formatField(issue.path),
+              message: issue.message,
+            })),
+          },
+        },
+        422,
+      );
+    }
+  });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@neondatabase/serverless':
         specifier: ^1.1.0
         version: 1.1.0
+      '@standard-schema/spec':
+        specifier: ^1.1.0
+        version: 1.1.0
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260501.1)(@neondatabase/serverless@1.1.0)


### PR DESCRIPTION
## Summary
- `sValidator` のラッパー `utils/validator.ts` を追加し、失敗時に統一フォーマット `{ error: { code: "VALIDATION_ERROR", message, details } }` を **422** で返すよう変更
- 既存ルート (`POST /v1/medicines`, `GET /v1/medicines`, `GET /v1/medicines/:id`) を新ラッパーに切り替え
- `details[].field` は valibot の `issue.path` を `.` 結合して算出

Closes #26

## Test plan
- [x] `GET /v1/medicines/:id` に不正な UUID → 422 で統一フォーマット
- [x] `GET /v1/medicines?today=foo` → 422 で統一フォーマット
- [x] `POST /v1/medicines` に不正な body → 422、複数 issue が `details[]` に展開される
- [x] 正常系 (`GET /v1/medicines`) は 200 のまま回帰なし
- [ ] 既存 Bruno コレクションで主要ケースを再確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/riku10145/nonda/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->