### PR TITLE
chore(deps): bump typescript to ^6 in apps/api

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,7 +28,7 @@
     "drizzle-kit": "^0.31.10",
     "oxfmt": "^0.47.0",
     "oxlint": "^1.62.0",
-    "typescript": "^5",
+    "typescript": "^6",
     "wrangler": "^4.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 4.12.16
       valibot:
         specifier: ^1.0.0
-        version: 1.3.1(typescript@5.9.3)
+        version: 1.3.1(typescript@6.0.3)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20251001.0
@@ -49,8 +49,8 @@ importers:
         specifier: ^1.62.0
         version: 1.62.0
       typescript:
-        specifier: ^5
-        version: 5.9.3
+        specifier: ^6
+        version: 6.0.3
       wrangler:
         specifier: ^4.0.0
         version: 4.87.0(@cloudflare/workers-types@4.20260501.1)
@@ -3123,11 +3123,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -6000,8 +5995,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.3: {}
-
   typescript@6.0.3: {}
 
   unbox-primitive@1.1.0:
@@ -6053,9 +6046,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  valibot@1.3.1(typescript@5.9.3):
+  valibot@1.3.1(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
## Summary
- \`apps/api\` の typescript を \`^5\` → \`^6\` に揃える(\`apps/web\` は既に \`^6\`)
- Dependabot PR #18 から TypeScript 部分のみを切り出し
- ESLint 10 は \`eslint-config-next\` / \`typescript-eslint\` の v10 サポート状況確認後に別 PR で対応

## Test plan
- [x] \`pnpm install\` で lockfile 更新確認
- [x] \`apps/api\`: \`tsc --noEmit\` 成功
- [x] \`apps/web\`: \`tsc --noEmit\` 成功
- [x] \`apps/web\`: \`next build\` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/riku10145/nonda/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->