### PR TITLE
feat(api): GET /v1/medication-logs (服用ログ一覧) を追加

### DIFF
--- a/apps/api/bruno/medication-logs/List medication-logs.bru
+++ b/apps/api/bruno/medication-logs/List medication-logs.bru
@@ -1,0 +1,29 @@
+meta {
+  name: List medication-logs
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/api/v1/medication-logs?from=2026-04-01&to=2026-05-06
+  body: none
+  auth: none
+}
+
+params:query {
+  from: 2026-04-01
+  to: 2026-05-06
+}
+
+headers {
+  x-user-id: {{devUserId}}
+}
+
+tests {
+  test("status is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("returns array", function() {
+    expect(res.getBody()).to.be.an("array");
+  });
+}

--- a/apps/api/src/routes/medication-logs/index.ts
+++ b/apps/api/src/routes/medication-logs/index.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import type { AppEnv } from "../../types/index.js";
 import { UUID_REGEX } from "../../utils/uuid.js";
 import { createMedicationLogsRoute } from "./create.js";
+import { listMedicationLogsRoute } from "./list.js";
 
 export const medicationLogsRoute = new Hono<AppEnv>();
 
@@ -18,3 +19,4 @@ medicationLogsRoute.use("*", async (c, next) => {
 });
 
 medicationLogsRoute.route("/", createMedicationLogsRoute);
+medicationLogsRoute.route("/", listMedicationLogsRoute);

--- a/apps/api/src/routes/medication-logs/list.test.ts
+++ b/apps/api/src/routes/medication-logs/list.test.ts
@@ -1,0 +1,107 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AppEnv, Bindings } from "../../types/index.js";
+
+const mockOrderBy = vi.fn();
+
+vi.mock("../../db/client.js", () => ({
+  createDbClient: () => ({
+    select: () => ({
+      from: () => ({
+        innerJoin: () => ({
+          where: () => ({ orderBy: mockOrderBy }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+const { medicationLogsRoute } = await import("./index.js");
+
+const userId = "87d8b9c6-00e8-42aa-ae8c-7d0e83aa2fb7";
+
+const env: Bindings = {
+  DATABASE_URL: "postgres://test",
+  FRONTEND_URL: "http://localhost:3000",
+};
+
+const buildApp = () => {
+  const app = new Hono<AppEnv>();
+  app.route("/v1/medication-logs", medicationLogsRoute);
+  return app;
+};
+
+const sendList = (query: string) =>
+  buildApp().request(
+    `/v1/medication-logs${query}`,
+    {
+      method: "GET",
+      headers: { "x-user-id": userId },
+    },
+    env,
+  );
+
+describe("GET /v1/medication-logs", () => {
+  beforeEach(() => {
+    mockOrderBy.mockReset();
+  });
+
+  it("returns 200 with logs grouped by JST date in date desc order", async () => {
+    mockOrderBy.mockResolvedValueOnce([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        medicineName: "薬 A",
+        timing: "morning",
+        isTaken: true,
+        recordedAt: new Date("2026-04-28T23:00:00.000Z"),
+      },
+      {
+        id: "22222222-2222-2222-2222-222222222222",
+        medicineName: "薬 A",
+        timing: "morning",
+        isTaken: true,
+        recordedAt: new Date("2026-04-29T23:00:00.000Z"),
+      },
+    ]);
+
+    const res = await sendList("?from=2026-04-29&to=2026-04-30");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([
+      {
+        date: "2026-04-30",
+        logs: [
+          {
+            id: "22222222-2222-2222-2222-222222222222",
+            medicine_name: "薬 A",
+            timing: "morning",
+            is_taken: true,
+            recorded_at: "2026-04-29T23:00:00.000Z",
+          },
+        ],
+      },
+      {
+        date: "2026-04-29",
+        logs: [
+          {
+            id: "11111111-1111-1111-1111-111111111111",
+            medicine_name: "薬 A",
+            timing: "morning",
+            is_taken: true,
+            recorded_at: "2026-04-28T23:00:00.000Z",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("returns 422 VALIDATION_ERROR when from / to is missing or malformed", async () => {
+    const res = await sendList("?from=2026-04-29");
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(mockOrderBy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/medication-logs/list.ts
+++ b/apps/api/src/routes/medication-logs/list.ts
@@ -1,0 +1,31 @@
+import { Hono } from "hono";
+
+import { createDbClient } from "../../db/client.js";
+import { ListMedicationLogsQuerySchema } from "../../schemas/medication-logs/index.js";
+import { listMedicationLogs } from "../../services/medication-logs/index.js";
+import type { AppEnv } from "../../types/index.js";
+import { validator } from "../../utils/validator.js";
+
+export const listMedicationLogsRoute = new Hono<AppEnv>().get(
+  "/",
+  validator("query", ListMedicationLogsQuerySchema),
+  async (c) => {
+    const userId = c.get("userId");
+    const { from, to } = c.req.valid("query");
+    const db = createDbClient(c.env.DATABASE_URL);
+
+    const groups = await listMedicationLogs(db, { userId, from, to });
+    return c.json(
+      groups.map((group) => ({
+        date: group.date,
+        logs: group.logs.map((log) => ({
+          id: log.id,
+          medicine_name: log.medicineName,
+          timing: log.timing,
+          is_taken: log.isTaken,
+          recorded_at: log.recordedAt.toISOString(),
+        })),
+      })),
+    );
+  },
+);

--- a/apps/api/src/schemas/medication-logs/index.ts
+++ b/apps/api/src/schemas/medication-logs/index.ts
@@ -1,1 +1,2 @@
 export { CreateMedicationLogsSchema, type CreateMedicationLogsInput } from "./create.js";
+export { ListMedicationLogsQuerySchema, type ListMedicationLogsQuery } from "./list.js";

--- a/apps/api/src/schemas/medication-logs/list.ts
+++ b/apps/api/src/schemas/medication-logs/list.ts
@@ -1,0 +1,9 @@
+import * as v from "valibot";
+
+/** GET /v1/medication-logs のクエリ。 from / to は JST 基準の "YYYY-MM-DD"。 */
+export const ListMedicationLogsQuerySchema = v.object({
+  from: v.pipe(v.string(), v.isoDate()),
+  to: v.pipe(v.string(), v.isoDate()),
+});
+
+export type ListMedicationLogsQuery = v.InferOutput<typeof ListMedicationLogsQuerySchema>;

--- a/apps/api/src/services/medication-logs/index.ts
+++ b/apps/api/src/services/medication-logs/index.ts
@@ -4,3 +4,9 @@ export {
   type CreateMedicationLogsParams,
   type CreateMedicationLogsResult,
 } from "./create.js";
+export {
+  listMedicationLogs,
+  type ListMedicationLogsParams,
+  type MedicationLogGroup,
+  type MedicationLogItem,
+} from "./list.js";

--- a/apps/api/src/services/medication-logs/list.test.ts
+++ b/apps/api/src/services/medication-logs/list.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Db } from "../../db/client.js";
+import { listMedicationLogs } from "./list.js";
+
+const userId = "87d8b9c6-00e8-42aa-ae8c-7d0e83aa2fb7";
+
+interface Row {
+  id: string;
+  medicineName: string;
+  timing: "morning" | "afternoon" | "evening";
+  isTaken: boolean;
+  recordedAt: Date;
+}
+
+const buildDb = (rows: Row[]) => {
+  const orderBy = vi.fn().mockResolvedValueOnce(rows);
+  const where = vi.fn(() => ({ orderBy }));
+  const innerJoin = vi.fn(() => ({ where }));
+  const from = vi.fn(() => ({ innerJoin }));
+  const select = vi.fn(() => ({ from }));
+  return { db: { select } as unknown as Db };
+};
+
+describe("listMedicationLogs", () => {
+  it("returns groups in date desc with logs in recordedAt asc, grouped by JST date", async () => {
+    // 2026-04-29 JST 08:00 = 2026-04-28T23:00:00Z
+    // 2026-04-29 JST 20:00 = 2026-04-29T11:00:00Z
+    // 2026-04-30 JST 08:00 = 2026-04-29T23:00:00Z
+    const { db } = buildDb([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        medicineName: "薬 A",
+        timing: "morning",
+        isTaken: true,
+        recordedAt: new Date("2026-04-28T23:00:00.000Z"),
+      },
+      {
+        id: "22222222-2222-2222-2222-222222222222",
+        medicineName: "薬 B",
+        timing: "evening",
+        isTaken: false,
+        recordedAt: new Date("2026-04-29T11:00:00.000Z"),
+      },
+      {
+        id: "33333333-3333-3333-3333-333333333333",
+        medicineName: "薬 A",
+        timing: "morning",
+        isTaken: true,
+        recordedAt: new Date("2026-04-29T23:00:00.000Z"),
+      },
+    ]);
+
+    const result = await listMedicationLogs(db, {
+      userId,
+      from: "2026-04-29",
+      to: "2026-04-30",
+    });
+
+    expect(result).toEqual([
+      {
+        date: "2026-04-30",
+        logs: [
+          {
+            id: "33333333-3333-3333-3333-333333333333",
+            medicineName: "薬 A",
+            timing: "morning",
+            isTaken: true,
+            recordedAt: new Date("2026-04-29T23:00:00.000Z"),
+          },
+        ],
+      },
+      {
+        date: "2026-04-29",
+        logs: [
+          {
+            id: "11111111-1111-1111-1111-111111111111",
+            medicineName: "薬 A",
+            timing: "morning",
+            isTaken: true,
+            recordedAt: new Date("2026-04-28T23:00:00.000Z"),
+          },
+          {
+            id: "22222222-2222-2222-2222-222222222222",
+            medicineName: "薬 B",
+            timing: "evening",
+            isTaken: false,
+            recordedAt: new Date("2026-04-29T11:00:00.000Z"),
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("returns an empty array when there are no logs in the period", async () => {
+    const { db } = buildDb([]);
+
+    const result = await listMedicationLogs(db, {
+      userId,
+      from: "2026-04-01",
+      to: "2026-04-30",
+    });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/api/src/services/medication-logs/list.ts
+++ b/apps/api/src/services/medication-logs/list.ts
@@ -1,0 +1,73 @@
+import { and, asc, eq, gte, lt } from "drizzle-orm";
+
+import type { Db } from "../../db/client.js";
+import { medicationLogs, medicines } from "../../db/schema.js";
+import type { Timing } from "../../schemas/medicines/timing.js";
+import { jstDateStringToUtc, utcToJstDateString } from "../../utils/jst.js";
+
+export interface MedicationLogItem {
+  id: string;
+  medicineName: string;
+  timing: Timing;
+  isTaken: boolean;
+  recordedAt: Date;
+}
+
+export interface MedicationLogGroup {
+  date: string;
+  logs: MedicationLogItem[];
+}
+
+export interface ListMedicationLogsParams {
+  userId: string;
+  from: string;
+  to: string;
+}
+
+const _ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * 指定ユーザー所有の薬に紐づく服用ログを、JST 基準の日付ごとにグループ化して返す。
+ * 期間は JST [from 00:00, to 24:00) （両端含む from / to の日）として扱う。
+ * @param db Drizzle クライアント
+ * @param params userId と JST 日付 "YYYY-MM-DD" の from / to
+ * @returns date 降順の日次グループ。各 logs は recordedAt 昇順。記録のない日は含まない
+ */
+export const listMedicationLogs = async (
+  db: Db,
+  params: ListMedicationLogsParams,
+): Promise<MedicationLogGroup[]> => {
+  const start = jstDateStringToUtc(params.from);
+  const end = new Date(jstDateStringToUtc(params.to).getTime() + _ONE_DAY_MS);
+
+  const rows = await db
+    .select({
+      id: medicationLogs.id,
+      medicineName: medicines.name,
+      timing: medicationLogs.timing,
+      isTaken: medicationLogs.isTaken,
+      recordedAt: medicationLogs.recordedAt,
+    })
+    .from(medicationLogs)
+    .innerJoin(medicines, eq(medicationLogs.medicineId, medicines.id))
+    .where(
+      and(
+        eq(medicines.userId, params.userId),
+        gte(medicationLogs.recordedAt, start),
+        lt(medicationLogs.recordedAt, end),
+      ),
+    )
+    .orderBy(asc(medicationLogs.recordedAt));
+
+  const groups = new Map<string, MedicationLogItem[]>();
+  for (const row of rows) {
+    const date = utcToJstDateString(row.recordedAt);
+    const bucket = groups.get(date) ?? [];
+    bucket.push(row);
+    groups.set(date, bucket);
+  }
+
+  return [...groups.entries()]
+    .sort(([a], [b]) => (a < b ? 1 : a > b ? -1 : 0))
+    .map(([date, logs]) => ({ date, logs }));
+};

--- a/apps/api/src/utils/jst.ts
+++ b/apps/api/src/utils/jst.ts
@@ -5,9 +5,9 @@
 const _JST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
 export const getJstTodayRange = (now: Date = new Date()): { start: Date; end: Date } => {
-  const jstNow = new Date(now.getTime() + JST_OFFSET_MS);
+  const jstNow = new Date(now.getTime() + _JST_OFFSET_MS);
   const jstMidnight = Date.UTC(jstNow.getUTCFullYear(), jstNow.getUTCMonth(), jstNow.getUTCDate());
-  const start = new Date(jstMidnight - JST_OFFSET_MS);
+  const start = new Date(jstMidnight - _JST_OFFSET_MS);
   const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
   return { start, end };
 };
@@ -15,11 +15,11 @@ export const getJstTodayRange = (now: Date = new Date()): { start: Date; end: Da
 // "YYYY-MM-DD" (JST) を JST 0:00 の UTC Date に変換する。
 export const jstDateStringToUtc = (dateStr: string): Date => {
   const [y, m, d] = dateStr.split("-").map(Number);
-  return new Date(Date.UTC(y, m - 1, d) - JST_OFFSET_MS);
+  return new Date(Date.UTC(y, m - 1, d) - _JST_OFFSET_MS);
 };
 
 // UTC Date を JST 基準の "YYYY-MM-DD" に変換する。
 export const utcToJstDateString = (date: Date): string => {
-  const jst = new Date(date.getTime() + JST_OFFSET_MS);
+  const jst = new Date(date.getTime() + _JST_OFFSET_MS);
   return jst.toISOString().slice(0, 10);
 };

--- a/apps/api/src/utils/jst.ts
+++ b/apps/api/src/utils/jst.ts
@@ -1,11 +1,25 @@
 // JST 固定で「今日」の UTC 範囲 [start, end) を返す。
 //Todo: ユーザーごとの timezone を持たせる場合はここを users.timezone 参照に差し替える。
 //Todo: タイムゾーン処理が増えたら date-fns-tz / Temporal などのライブラリ導入を検討する。
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
 export const getJstTodayRange = (now: Date = new Date()): { start: Date; end: Date } => {
-  const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
   const jstNow = new Date(now.getTime() + JST_OFFSET_MS);
   const jstMidnight = Date.UTC(jstNow.getUTCFullYear(), jstNow.getUTCMonth(), jstNow.getUTCDate());
   const start = new Date(jstMidnight - JST_OFFSET_MS);
   const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
   return { start, end };
+};
+
+// "YYYY-MM-DD" (JST) を JST 0:00 の UTC Date に変換する。
+export const jstDateStringToUtc = (dateStr: string): Date => {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, d) - JST_OFFSET_MS);
+};
+
+// UTC Date を JST 基準の "YYYY-MM-DD" に変換する。
+export const utcToJstDateString = (date: Date): string => {
+  const jst = new Date(date.getTime() + JST_OFFSET_MS);
+  return jst.toISOString().slice(0, 10);
 };

--- a/apps/api/src/utils/jst.ts
+++ b/apps/api/src/utils/jst.ts
@@ -2,7 +2,7 @@
 //Todo: ユーザーごとの timezone を持たせる場合はここを users.timezone 参照に差し替える。
 //Todo: タイムゾーン処理が増えたら date-fns-tz / Temporal などのライブラリ導入を検討する。
 
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+const _JST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
 export const getJstTodayRange = (now: Date = new Date()): { start: Date; end: Date } => {
   const jstNow = new Date(now.getTime() + JST_OFFSET_MS);


### PR DESCRIPTION
## Summary

- 自分の薬に紐づく服用ログを期間指定で取得する `GET /api/v1/medication-logs?from=YYYY-MM-DD&to=YYYY-MM-DD` を追加
- `medicines` と JOIN して `medicine_name` を含め、JST 基準の日付ごとにグループ化して返す（date 降順 / 各 logs は recorded_at 昇順、記録のない日は除外）
- `from`/`to` は valibot で検証し、欠落・不正フォーマットは 422 `VALIDATION_ERROR`
- 認証は既存と同じ `x-user-id` スタブを利用
- JST 日付 ↔ UTC の相互変換ヘルパー (`jstDateStringToUtc` / `utcToJstDateString`) を `utils/jst.ts` に追加
- `services` ユニットテストと `routes` 統合テスト（200 と 422）を追加
- Bruno に `List medication-logs.bru` を追加

> このブランチは `feat/medication-logs-create` 上のスタック PR です。

## Test plan

- [ ] `pnpm --filter api lint`
- [ ] `pnpm --filter api fmt:check`
- [ ] `pnpm --filter api test`
- [ ] Bruno で `from` / `to` 指定の GET が 200 で日付グループ配列を返すこと
- [ ] `from` を欠いた / 不正フォーマットのリクエストが 422 `VALIDATION_ERROR` で返ること
- [ ] 他ユーザー所有の薬のログが含まれないこと


---
_Generated by [Claude Code](https://claude.ai/code/session_01A5RnYqBfLpM41QydjCejxU)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/riku10145/nonda/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->