### PR TITLE
feat(api): PATCH /v1/medication-logs/:id (服用ログの部分更新) を追加

### DIFF
--- a/apps/api/bruno/medication-logs/Update medication-log.bru
+++ b/apps/api/bruno/medication-logs/Update medication-log.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Update medication-log
+  type: http
+  seq: 3
+}
+
+patch {
+  url: {{baseUrl}}/api/v1/medication-logs/{{medicationLogId}}
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-user-id: {{devUserId}}
+}
+
+body:json {
+  {
+    "is_taken": false
+  }
+}
+
+tests {
+  test("status is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("returns id", function() {
+    expect(res.getBody().id).to.be.a("string");
+  });
+  test("returns is_taken", function() {
+    expect(res.getBody().is_taken).to.be.a("boolean");
+  });
+  test("returns updated_at", function() {
+    expect(res.getBody().updated_at).to.be.a("string");
+  });
+}

--- a/apps/api/src/routes/medication-logs/index.ts
+++ b/apps/api/src/routes/medication-logs/index.ts
@@ -4,6 +4,7 @@ import type { AppEnv } from "../../types/index.js";
 import { UUID_REGEX } from "../../utils/uuid.js";
 import { createMedicationLogsRoute } from "./create.js";
 import { listMedicationLogsRoute } from "./list.js";
+import { updateMedicationLogRoute } from "./update.js";
 
 export const medicationLogsRoute = new Hono<AppEnv>();
 
@@ -20,3 +21,4 @@ medicationLogsRoute.use("*", async (c, next) => {
 
 medicationLogsRoute.route("/", createMedicationLogsRoute);
 medicationLogsRoute.route("/", listMedicationLogsRoute);
+medicationLogsRoute.route("/", updateMedicationLogRoute);

--- a/apps/api/src/routes/medication-logs/update.test.ts
+++ b/apps/api/src/routes/medication-logs/update.test.ts
@@ -1,0 +1,98 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AppEnv, Bindings } from "../../types/index.js";
+
+const mockSelectLimit = vi.fn();
+const mockUpdateReturning = vi.fn();
+
+vi.mock("../../db/client.js", () => ({
+  createDbClient: () => ({
+    select: () => ({
+      from: () => ({
+        innerJoin: () => ({
+          where: () => ({ limit: mockSelectLimit }),
+        }),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: () => ({ returning: mockUpdateReturning }),
+      }),
+    }),
+  }),
+}));
+
+const { medicationLogsRoute } = await import("./index.js");
+
+const userId = "87d8b9c6-00e8-42aa-ae8c-7d0e83aa2fb7";
+const otherUserId = "11111111-1111-1111-1111-111111111111";
+const logId = "22222222-2222-2222-2222-222222222222";
+
+const env: Bindings = {
+  DATABASE_URL: "postgres://test",
+  FRONTEND_URL: "http://localhost:3000",
+};
+
+const buildApp = () => {
+  const app = new Hono<AppEnv>();
+  app.route("/v1/medication-logs", medicationLogsRoute);
+  return app;
+};
+
+const sendUpdate = (id: string, body: unknown) =>
+  buildApp().request(
+    `/v1/medication-logs/${id}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "x-user-id": userId },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+
+describe("PATCH /v1/medication-logs/:id", () => {
+  beforeEach(() => {
+    mockSelectLimit.mockReset();
+    mockUpdateReturning.mockReset();
+  });
+
+  it("returns 200 with the updated log when the log is owned by the user", async () => {
+    const updatedAt = new Date("2026-05-06T12:00:00.000Z");
+    mockSelectLimit.mockResolvedValueOnce([{ id: logId, ownerId: userId }]);
+    mockUpdateReturning.mockResolvedValueOnce([{ id: logId, isTaken: false, updatedAt }]);
+
+    const res = await sendUpdate(logId, { is_taken: false });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      id: logId,
+      is_taken: false,
+      updated_at: updatedAt.toISOString(),
+    });
+  });
+
+  it("returns 403 FORBIDDEN when the log belongs to another user", async () => {
+    mockSelectLimit.mockResolvedValueOnce([{ id: logId, ownerId: otherUserId }]);
+
+    const res = await sendUpdate(logId, { is_taken: true });
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({
+      error: { code: "FORBIDDEN", message: "指定された服用ログの操作権限がありません" },
+    });
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 NOT_FOUND when the log does not exist", async () => {
+    mockSelectLimit.mockResolvedValueOnce([]);
+
+    const res = await sendUpdate(logId, { is_taken: true });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({
+      error: { code: "NOT_FOUND", message: "指定された服用ログが見つかりません" },
+    });
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/medication-logs/update.ts
+++ b/apps/api/src/routes/medication-logs/update.ts
@@ -1,0 +1,48 @@
+import { Hono } from "hono";
+
+import { createDbClient } from "../../db/client.js";
+import {
+  UpdateMedicationLogParamSchema,
+  UpdateMedicationLogSchema,
+} from "../../schemas/medication-logs/index.js";
+import { updateMedicationLog } from "../../services/medication-logs/index.js";
+import type { AppEnv } from "../../types/index.js";
+import { validator } from "../../utils/validator.js";
+
+export const updateMedicationLogRoute = new Hono<AppEnv>().patch(
+  "/:id",
+  validator("param", UpdateMedicationLogParamSchema),
+  validator("json", UpdateMedicationLogSchema),
+  async (c) => {
+    const userId = c.get("userId");
+    const { id: logId } = c.req.valid("param");
+    const body = c.req.valid("json");
+
+    const db = createDbClient(c.env.DATABASE_URL);
+    const result = await updateMedicationLog(db, {
+      userId,
+      logId,
+      isTaken: body.is_taken,
+    });
+
+    if ("notFound" in result) {
+      return c.json(
+        { error: { code: "NOT_FOUND", message: "指定された服用ログが見つかりません" } },
+        404,
+      );
+    }
+
+    if ("forbidden" in result) {
+      return c.json(
+        { error: { code: "FORBIDDEN", message: "指定された服用ログの操作権限がありません" } },
+        403,
+      );
+    }
+
+    return c.json({
+      id: result.updated.id,
+      is_taken: result.updated.isTaken,
+      updated_at: result.updated.updatedAt,
+    });
+  },
+);

--- a/apps/api/src/schemas/medication-logs/index.ts
+++ b/apps/api/src/schemas/medication-logs/index.ts
@@ -1,2 +1,8 @@
 export { CreateMedicationLogsSchema, type CreateMedicationLogsInput } from "./create.js";
 export { ListMedicationLogsQuerySchema, type ListMedicationLogsQuery } from "./list.js";
+export {
+  UpdateMedicationLogParamSchema,
+  UpdateMedicationLogSchema,
+  type UpdateMedicationLogInput,
+  type UpdateMedicationLogParam,
+} from "./update.js";

--- a/apps/api/src/schemas/medication-logs/update.ts
+++ b/apps/api/src/schemas/medication-logs/update.ts
@@ -1,0 +1,17 @@
+import * as v from "valibot";
+
+import { UUID_REGEX } from "../../utils/uuid.js";
+
+/** PATCH /v1/medication-logs/:id のパスパラメータ。 */
+export const UpdateMedicationLogParamSchema = v.object({
+  id: v.pipe(v.string(), v.regex(UUID_REGEX)),
+});
+
+export type UpdateMedicationLogParam = v.InferOutput<typeof UpdateMedicationLogParamSchema>;
+
+/** PATCH /v1/medication-logs/:id のリクエストボディ。 */
+export const UpdateMedicationLogSchema = v.object({
+  is_taken: v.boolean(),
+});
+
+export type UpdateMedicationLogInput = v.InferOutput<typeof UpdateMedicationLogSchema>;

--- a/apps/api/src/services/medication-logs/index.ts
+++ b/apps/api/src/services/medication-logs/index.ts
@@ -10,3 +10,9 @@ export {
   type MedicationLogGroup,
   type MedicationLogItem,
 } from "./list.js";
+export {
+  updateMedicationLog,
+  type UpdatedMedicationLog,
+  type UpdateMedicationLogParams,
+  type UpdateMedicationLogResult,
+} from "./update.js";

--- a/apps/api/src/services/medication-logs/update.test.ts
+++ b/apps/api/src/services/medication-logs/update.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Db } from "../../db/client.js";
+import { updateMedicationLog } from "./update.js";
+
+const userId = "87d8b9c6-00e8-42aa-ae8c-7d0e83aa2fb7";
+const otherUserId = "11111111-1111-1111-1111-111111111111";
+const logId = "22222222-2222-2222-2222-222222222222";
+
+const buildDb = (
+  selectRows: { id: string; ownerId: string }[],
+  updatedRows: { id: string; isTaken: boolean; updatedAt: Date }[],
+) => {
+  const limit = vi.fn().mockResolvedValueOnce(selectRows);
+  const where = vi.fn(() => ({ limit }));
+  const innerJoin = vi.fn(() => ({ where }));
+  const from = vi.fn(() => ({ innerJoin }));
+  const select = vi.fn(() => ({ from }));
+
+  const returning = vi.fn().mockResolvedValueOnce(updatedRows);
+  const updateWhere = vi.fn(() => ({ returning }));
+  const set = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set }));
+
+  return { db: { select, update } as unknown as Db, set, update };
+};
+
+describe("updateMedicationLog", () => {
+  it("updates is_taken when the log is owned by the user", async () => {
+    const updatedAt = new Date("2026-05-06T12:00:00.000Z");
+    const { db, set } = buildDb(
+      [{ id: logId, ownerId: userId }],
+      [{ id: logId, isTaken: false, updatedAt }],
+    );
+
+    const result = await updateMedicationLog(db, { userId, logId, isTaken: false });
+
+    expect(result).toEqual({ updated: { id: logId, isTaken: false, updatedAt } });
+    expect(set).toHaveBeenCalledTimes(1);
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ isTaken: false, updatedAt: expect.any(Date) }),
+    );
+  });
+
+  it("returns notFound and skips the update when the log does not exist", async () => {
+    const { db, update } = buildDb([], []);
+
+    const result = await updateMedicationLog(db, { userId, logId, isTaken: true });
+
+    expect(result).toEqual({ notFound: true });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("returns forbidden and skips the update when the medicine belongs to another user", async () => {
+    const { db, update } = buildDb([{ id: logId, ownerId: otherUserId }], []);
+
+    const result = await updateMedicationLog(db, { userId, logId, isTaken: true });
+
+    expect(result).toEqual({ forbidden: true });
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/medication-logs/update.ts
+++ b/apps/api/src/services/medication-logs/update.ts
@@ -57,5 +57,9 @@ export const updateMedicationLog = async (
       updatedAt: medicationLogs.updatedAt,
     });
 
+  if (!updated) {
+    return { notFound: true };
+  }
+
   return { updated };
 };

--- a/apps/api/src/services/medication-logs/update.ts
+++ b/apps/api/src/services/medication-logs/update.ts
@@ -1,0 +1,61 @@
+import { eq } from "drizzle-orm";
+
+import type { Db } from "../../db/client.js";
+import { medicationLogs, medicines } from "../../db/schema.js";
+
+export interface UpdateMedicationLogParams {
+  userId: string;
+  logId: string;
+  isTaken: boolean;
+}
+
+export interface UpdatedMedicationLog {
+  id: string;
+  isTaken: boolean;
+  updatedAt: Date;
+}
+
+export type UpdateMedicationLogResult =
+  | { updated: UpdatedMedicationLog }
+  | { notFound: true }
+  | { forbidden: true };
+
+/**
+ * 服用ログの is_taken を部分更新する。
+ * 対象 log の medicine が userId の所有でなければ `{ forbidden: true }`、
+ * 存在しなければ `{ notFound: true }` を返す。
+ * @param db Drizzle クライアント
+ * @param params 更新対象の logId / 所有 userId / 新しい isTaken
+ * @returns 更新後の log、所有外なら forbidden、未存在なら notFound
+ */
+export const updateMedicationLog = async (
+  db: Db,
+  params: UpdateMedicationLogParams,
+): Promise<UpdateMedicationLogResult> => {
+  const [target] = await db
+    .select({ id: medicationLogs.id, ownerId: medicines.userId })
+    .from(medicationLogs)
+    .innerJoin(medicines, eq(medicationLogs.medicineId, medicines.id))
+    .where(eq(medicationLogs.id, params.logId))
+    .limit(1);
+
+  if (!target) {
+    return { notFound: true };
+  }
+
+  if (target.ownerId !== params.userId) {
+    return { forbidden: true };
+  }
+
+  const [updated] = await db
+    .update(medicationLogs)
+    .set({ isTaken: params.isTaken, updatedAt: new Date() })
+    .where(eq(medicationLogs.id, params.logId))
+    .returning({
+      id: medicationLogs.id,
+      isTaken: medicationLogs.isTaken,
+      updatedAt: medicationLogs.updatedAt,
+    });
+
+  return { updated };
+};


### PR DESCRIPTION
## Summary

- 服用ログの `is_taken` を部分更新する `PATCH /api/v1/medication-logs/:id` を追加
- 対象ログを `medication_logs` × `medicines` の JOIN で引き当て、`x-user-id` の所有でなければ 403 `FORBIDDEN`、存在しなければ 404 `NOT_FOUND` を返す
- 成功時は 200 で `{ id, is_taken, updated_at }` を返却（部分更新なので PUT ではなく PATCH）
- 認証は既存と同じ `x-user-id` スタブを利用
- `services` のユニットテスト (3 ケース) と `routes` の統合テスト (3 ケース) を共置
- Bruno に `Update medication-log.bru` を追加

> このブランチは `feat/medication-logs-list` 上のスタック PR (3 本目) です。

## Test plan

- [ ] `pnpm --filter api lint`
- [ ] `pnpm --filter api fmt:check`
- [ ] `pnpm --filter api test`
- [ ] Bruno で `is_taken: false` の PATCH が 200 で `{ id, is_taken, updated_at }` を返すこと
- [ ] 他ユーザー所有の薬に紐づくログへの PATCH が 403 `FORBIDDEN` で返ること
- [ ] 存在しない id への PATCH が 404 `NOT_FOUND` で返ること
- [ ] `is_taken` 欠落 / 型不一致のリクエストが 422 `VALIDATION_ERROR` で返ること

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2czrANY2qpnCGtHdGAXJN)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/riku10145/nonda/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->