### PR TITLE
feat(api): GET /v1/notification-settings (通知設定一覧) を追加

### DIFF
--- a/apps/api/bruno/notification-settings/List notification-settings.bru
+++ b/apps/api/bruno/notification-settings/List notification-settings.bru
@@ -1,0 +1,39 @@
+meta {
+  name: List notification-settings
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/v1/notification-settings
+  body: none
+  auth: none
+}
+
+headers {
+  x-user-id: {{devUserId}}
+}
+
+tests {
+  test("status is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("returns array of length 3", function() {
+    const body = res.getBody();
+    expect(body).to.be.an("array");
+    expect(body.length).to.equal(3);
+  });
+  test("returns morning -> afternoon -> evening in order", function() {
+    const body = res.getBody();
+    expect(body[0].timing).to.equal("morning");
+    expect(body[1].timing).to.equal("afternoon");
+    expect(body[2].timing).to.equal("evening");
+  });
+  test("each item has notify_time and is_enabled", function() {
+    const body = res.getBody();
+    body.forEach(function(item) {
+      expect(item.notify_time).to.be.a("string");
+      expect(item.is_enabled).to.be.a("boolean");
+    });
+  });
+}

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import type { Bindings } from "../types/index.js";
 import { medicationLogsRoute } from "./medication-logs/index.js";
 import { medicinesRoute } from "./medicines/index.js";
+import { notificationSettingsRoute } from "./notification-settings/index.js";
 
 export const routes = new Hono<{ Bindings: Bindings }>();
 
@@ -10,3 +11,4 @@ routes.get("/", (c) => c.json({ message: "nonda API" }));
 
 routes.route("/v1/medicines", medicinesRoute);
 routes.route("/v1/medication-logs", medicationLogsRoute);
+routes.route("/v1/notification-settings", notificationSettingsRoute);

--- a/apps/api/src/routes/notification-settings/index.ts
+++ b/apps/api/src/routes/notification-settings/index.ts
@@ -1,0 +1,20 @@
+import { Hono } from "hono";
+
+import type { AppEnv } from "../../types/index.js";
+import { UUID_REGEX } from "../../utils/uuid.js";
+import { listNotificationSettingsRoute } from "./list.js";
+
+export const notificationSettingsRoute = new Hono<AppEnv>();
+
+// 認証スタブ: x-user-id ヘッダで userId を受け取る。本番では Auth.js セッション検証に差し替える。
+//Todo: ブラウザから叩く前に index.ts の CORS allowHeaders に x-user-id を追加する（現状は Bruno など非ブラウザのみ動作）
+notificationSettingsRoute.use("*", async (c, next) => {
+  const userId = c.req.header("x-user-id");
+  if (!userId || !UUID_REGEX.test(userId)) {
+    return c.json({ error: { code: "UNAUTHORIZED", message: "ログインが必要です" } }, 401);
+  }
+  c.set("userId", userId);
+  await next();
+});
+
+notificationSettingsRoute.route("/", listNotificationSettingsRoute);

--- a/apps/api/src/routes/notification-settings/list.test.ts
+++ b/apps/api/src/routes/notification-settings/list.test.ts
@@ -1,0 +1,84 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AppEnv, Bindings } from "../../types/index.js";
+
+const mockSelectWhere = vi.fn();
+
+vi.mock("../../db/client.js", () => ({
+  createDbClient: () => ({
+    select: () => ({
+      from: () => ({ where: mockSelectWhere }),
+    }),
+  }),
+}));
+
+const { notificationSettingsRoute } = await import("./index.js");
+
+const userId = "87d8b9c6-00e8-42aa-ae8c-7d0e83aa2fb7";
+
+const env: Bindings = {
+  DATABASE_URL: "postgres://test",
+  FRONTEND_URL: "http://localhost:3000",
+};
+
+const buildApp = () => {
+  const app = new Hono<AppEnv>();
+  app.route("/v1/notification-settings", notificationSettingsRoute);
+  return app;
+};
+
+const sendList = (headers: Record<string, string> = { "x-user-id": userId }) =>
+  buildApp().request("/v1/notification-settings", { method: "GET", headers }, env);
+
+describe("GET /v1/notification-settings", () => {
+  beforeEach(() => {
+    mockSelectWhere.mockReset();
+  });
+
+  it("returns 200 with stored settings filled by defaults in fixed timing order", async () => {
+    mockSelectWhere.mockResolvedValueOnce([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        timing: "morning",
+        notifyTime: "07:30:00",
+        isEnabled: false,
+      },
+      {
+        id: "22222222-2222-2222-2222-222222222222",
+        timing: "evening",
+        notifyTime: "21:00:00",
+        isEnabled: true,
+      },
+    ]);
+
+    const res = await sendList();
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        timing: "morning",
+        notify_time: "07:30",
+        is_enabled: false,
+      },
+      { id: null, timing: "afternoon", notify_time: "12:00", is_enabled: true },
+      {
+        id: "22222222-2222-2222-2222-222222222222",
+        timing: "evening",
+        notify_time: "21:00",
+        is_enabled: true,
+      },
+    ]);
+  });
+
+  it("returns 401 UNAUTHORIZED when x-user-id is missing", async () => {
+    const res = await sendList({});
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({
+      error: { code: "UNAUTHORIZED", message: "ログインが必要です" },
+    });
+    expect(mockSelectWhere).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/notification-settings/list.ts
+++ b/apps/api/src/routes/notification-settings/list.ts
@@ -1,0 +1,20 @@
+import { Hono } from "hono";
+
+import { createDbClient } from "../../db/client.js";
+import { listNotificationSettings } from "../../services/notification-settings/index.js";
+import type { AppEnv } from "../../types/index.js";
+
+export const listNotificationSettingsRoute = new Hono<AppEnv>().get("/", async (c) => {
+  const userId = c.get("userId");
+  const db = createDbClient(c.env.DATABASE_URL);
+
+  const settings = await listNotificationSettings(db, { userId });
+  return c.json(
+    settings.map((setting) => ({
+      id: setting.id,
+      timing: setting.timing,
+      notify_time: setting.notifyTime,
+      is_enabled: setting.isEnabled,
+    })),
+  );
+});

--- a/apps/api/src/services/notification-settings/index.ts
+++ b/apps/api/src/services/notification-settings/index.ts
@@ -1,0 +1,5 @@
+export {
+  listNotificationSettings,
+  type ListNotificationSettingsParams,
+  type NotificationSettingItem,
+} from "./list.js";

--- a/apps/api/src/services/notification-settings/list.test.ts
+++ b/apps/api/src/services/notification-settings/list.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Db } from "../../db/client.js";
+import { listNotificationSettings } from "./list.js";
+
+const userId = "87d8b9c6-00e8-42aa-ae8c-7d0e83aa2fb7";
+
+interface Row {
+  id: string;
+  timing: "morning" | "afternoon" | "evening";
+  notifyTime: string;
+  isEnabled: boolean;
+}
+
+const buildDb = (rows: Row[]) => {
+  const where = vi.fn().mockResolvedValueOnce(rows);
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+  return { db: { select } as unknown as Db };
+};
+
+describe("listNotificationSettings", () => {
+  it("returns morning -> afternoon -> evening, normalizing TIME values to HH:MM", async () => {
+    const { db } = buildDb([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        timing: "evening",
+        notifyTime: "21:00:00",
+        isEnabled: true,
+      },
+      {
+        id: "22222222-2222-2222-2222-222222222222",
+        timing: "morning",
+        notifyTime: "07:30:00",
+        isEnabled: false,
+      },
+      {
+        id: "33333333-3333-3333-3333-333333333333",
+        timing: "afternoon",
+        notifyTime: "12:00:00",
+        isEnabled: true,
+      },
+    ]);
+
+    const result = await listNotificationSettings(db, { userId });
+
+    expect(result).toEqual([
+      {
+        id: "22222222-2222-2222-2222-222222222222",
+        timing: "morning",
+        notifyTime: "07:30",
+        isEnabled: false,
+      },
+      {
+        id: "33333333-3333-3333-3333-333333333333",
+        timing: "afternoon",
+        notifyTime: "12:00",
+        isEnabled: true,
+      },
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        timing: "evening",
+        notifyTime: "21:00",
+        isEnabled: true,
+      },
+    ]);
+  });
+
+  it("fills missing timings with defaults (id null, is_enabled true)", async () => {
+    const { db } = buildDb([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        timing: "morning",
+        notifyTime: "07:30:00",
+        isEnabled: false,
+      },
+    ]);
+
+    const result = await listNotificationSettings(db, { userId });
+
+    expect(result).toEqual([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        timing: "morning",
+        notifyTime: "07:30",
+        isEnabled: false,
+      },
+      { id: null, timing: "afternoon", notifyTime: "12:00", isEnabled: true },
+      { id: null, timing: "evening", notifyTime: "21:00", isEnabled: true },
+    ]);
+  });
+
+  it("returns all defaults when the user has no settings yet", async () => {
+    const { db } = buildDb([]);
+
+    const result = await listNotificationSettings(db, { userId });
+
+    expect(result).toEqual([
+      { id: null, timing: "morning", notifyTime: "08:00", isEnabled: true },
+      { id: null, timing: "afternoon", notifyTime: "12:00", isEnabled: true },
+      { id: null, timing: "evening", notifyTime: "21:00", isEnabled: true },
+    ]);
+  });
+});

--- a/apps/api/src/services/notification-settings/list.ts
+++ b/apps/api/src/services/notification-settings/list.ts
@@ -1,0 +1,69 @@
+import { and, eq } from "drizzle-orm";
+
+import type { Db } from "../../db/client.js";
+import { notificationSettings } from "../../db/schema.js";
+import type { Timing } from "../../schemas/medicines/timing.js";
+
+export interface NotificationSettingItem {
+  id: string | null;
+  timing: Timing;
+  notifyTime: string;
+  isEnabled: boolean;
+}
+
+export interface ListNotificationSettingsParams {
+  userId: string;
+}
+
+const _DEFAULT_NOTIFY_TIMES = {
+  morning: "08:00",
+  afternoon: "12:00",
+  evening: "21:00",
+} as const satisfies Record<Timing, string>;
+
+const _TIMING_ORDER: readonly Timing[] = ["morning", "afternoon", "evening"];
+
+const _normalizeTime = (value: string): string => value.slice(0, 5);
+
+/**
+ * 指定ユーザーの通知設定を朝/昼/夕の固定順で返す。
+ * 未登録のタイミングはデフォルト時刻 (08:00 / 12:00 / 21:00) と is_enabled=true で補完し、
+ * `id` は null を返す。
+ * @param db Drizzle クライアント
+ * @param params 取得対象の userId
+ * @returns morning -> afternoon -> evening の順に並んだ通知設定（必ず3件）
+ */
+export const listNotificationSettings = async (
+  db: Db,
+  params: ListNotificationSettingsParams,
+): Promise<NotificationSettingItem[]> => {
+  const rows = await db
+    .select({
+      id: notificationSettings.id,
+      timing: notificationSettings.timing,
+      notifyTime: notificationSettings.notifyTime,
+      isEnabled: notificationSettings.isEnabled,
+    })
+    .from(notificationSettings)
+    .where(and(eq(notificationSettings.userId, params.userId)));
+
+  const byTiming = new Map(rows.map((row) => [row.timing, row]));
+
+  return _TIMING_ORDER.map<NotificationSettingItem>((timing) => {
+    const row = byTiming.get(timing);
+    if (row) {
+      return {
+        id: row.id,
+        timing,
+        notifyTime: _normalizeTime(row.notifyTime),
+        isEnabled: row.isEnabled,
+      };
+    }
+    return {
+      id: null,
+      timing,
+      notifyTime: _DEFAULT_NOTIFY_TIMES[timing],
+      isEnabled: true,
+    };
+  });
+};


### PR DESCRIPTION
設計書「🎨 設計」の通知設定エンドポイントを実装。未登録ユーザーには
デフォルト (morning 08:00 / afternoon 12:00 / evening 21:00, is_enabled=true)
を補完して必ず3件を返す。レスポンスは morning -> afternoon -> evening の固定順。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/riku10145/nonda/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->