### PR TITLE
feat(api): PUT /v1/notification-settings (通知設定の一括更新)

### DIFF
--- a/apps/api/bruno/notification-settings/Update notification-settings.bru
+++ b/apps/api/bruno/notification-settings/Update notification-settings.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Update notification-settings
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{baseUrl}}/api/v1/notification-settings
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  x-user-id: {{devUserId}}
+}
+
+body:json {
+  [
+    { "timing": "morning",   "notify_time": "07:30", "is_enabled": true },
+    { "timing": "afternoon", "notify_time": "12:00", "is_enabled": false },
+    { "timing": "evening",   "notify_time": "21:00", "is_enabled": true }
+  ]
+}
+
+tests {
+  test("status is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("returns updated count", function() {
+    const body = res.getBody();
+    expect(body.updated).to.be.a("number");
+    expect(body.updated).to.equal(3);
+  });
+}

--- a/apps/api/src/routes/notification-settings/index.ts
+++ b/apps/api/src/routes/notification-settings/index.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import type { AppEnv } from "../../types/index.js";
 import { UUID_REGEX } from "../../utils/uuid.js";
 import { listNotificationSettingsRoute } from "./list.js";
+import { updateNotificationSettingsRoute } from "./update.js";
 
 export const notificationSettingsRoute = new Hono<AppEnv>();
 
@@ -18,3 +19,4 @@ notificationSettingsRoute.use("*", async (c, next) => {
 });
 
 notificationSettingsRoute.route("/", listNotificationSettingsRoute);
+notificationSettingsRoute.route("/", updateNotificationSettingsRoute);

--- a/apps/api/src/routes/notification-settings/update.test.ts
+++ b/apps/api/src/routes/notification-settings/update.test.ts
@@ -1,0 +1,92 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AppEnv, Bindings } from "../../types/index.js";
+
+const mockInsertReturning = vi.fn();
+
+vi.mock("../../db/client.js", () => ({
+  createDbClient: () => ({
+    insert: () => ({
+      values: () => ({
+        onConflictDoUpdate: () => ({ returning: mockInsertReturning }),
+      }),
+    }),
+  }),
+}));
+
+const { notificationSettingsRoute } = await import("./index.js");
+
+const userId = "87d8b9c6-00e8-42aa-ae8c-7d0e83aa2fb7";
+
+const env: Bindings = {
+  DATABASE_URL: "postgres://test",
+  FRONTEND_URL: "http://localhost:3000",
+};
+
+const buildApp = () => {
+  const app = new Hono<AppEnv>();
+  app.route("/v1/notification-settings", notificationSettingsRoute);
+  return app;
+};
+
+const sendUpdate = (body: unknown, headers: Record<string, string> = { "x-user-id": userId }) =>
+  buildApp().request(
+    "/v1/notification-settings",
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+
+describe("PUT /v1/notification-settings", () => {
+  beforeEach(() => {
+    mockInsertReturning.mockReset();
+  });
+
+  it("returns 200 with updated count when all timings are upserted", async () => {
+    mockInsertReturning.mockResolvedValueOnce([
+      { id: "11111111-1111-1111-1111-111111111111" },
+      { id: "22222222-2222-2222-2222-222222222222" },
+      { id: "33333333-3333-3333-3333-333333333333" },
+    ]);
+
+    const res = await sendUpdate([
+      { timing: "morning", notify_time: "07:30", is_enabled: true },
+      { timing: "afternoon", notify_time: "12:00", is_enabled: false },
+      { timing: "evening", notify_time: "21:00", is_enabled: true },
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ updated: 3 });
+  });
+
+  it("returns 422 VALIDATION_ERROR when notify_time is not HH:MM", async () => {
+    const res = await sendUpdate([{ timing: "morning", notify_time: "7:30", is_enabled: true }]);
+
+    expect(res.status).toBe(422);
+    expect(mockInsertReturning).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 VALIDATION_ERROR when timings are duplicated", async () => {
+    const res = await sendUpdate([
+      { timing: "morning", notify_time: "07:30", is_enabled: true },
+      { timing: "morning", notify_time: "08:00", is_enabled: false },
+    ]);
+
+    expect(res.status).toBe(422);
+    expect(mockInsertReturning).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 UNAUTHORIZED when x-user-id is missing", async () => {
+    const res = await sendUpdate(
+      [{ timing: "morning", notify_time: "07:30", is_enabled: true }],
+      {},
+    );
+
+    expect(res.status).toBe(401);
+    expect(mockInsertReturning).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/notification-settings/update.ts
+++ b/apps/api/src/routes/notification-settings/update.ts
@@ -1,0 +1,28 @@
+import { Hono } from "hono";
+
+import { createDbClient } from "../../db/client.js";
+import { UpdateNotificationSettingsSchema } from "../../schemas/notification-settings/index.js";
+import { updateNotificationSettings } from "../../services/notification-settings/index.js";
+import type { AppEnv } from "../../types/index.js";
+import { validator } from "../../utils/validator.js";
+
+export const updateNotificationSettingsRoute = new Hono<AppEnv>().put(
+  "/",
+  validator("json", UpdateNotificationSettingsSchema),
+  async (c) => {
+    const userId = c.get("userId");
+    const body = c.req.valid("json");
+
+    const db = createDbClient(c.env.DATABASE_URL);
+    const { updated } = await updateNotificationSettings(db, {
+      userId,
+      items: body.map((item) => ({
+        timing: item.timing,
+        notifyTime: item.notify_time,
+        isEnabled: item.is_enabled,
+      })),
+    });
+
+    return c.json({ updated });
+  },
+);

--- a/apps/api/src/schemas/notification-settings/index.ts
+++ b/apps/api/src/schemas/notification-settings/index.ts
@@ -1,0 +1,4 @@
+export {
+  UpdateNotificationSettingsSchema,
+  type UpdateNotificationSettingsInput,
+} from "./update.js";

--- a/apps/api/src/schemas/notification-settings/update.ts
+++ b/apps/api/src/schemas/notification-settings/update.ts
@@ -1,0 +1,29 @@
+import * as v from "valibot";
+
+import { TimingSchema } from "../medicines/timing.js";
+
+const _NOTIFY_TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+const _NotificationSettingItemSchema = v.object({
+  timing: TimingSchema,
+  notify_time: v.pipe(
+    v.string(),
+    v.regex(_NOTIFY_TIME_REGEX, "notify_time は HH:MM 形式で指定してください"),
+  ),
+  is_enabled: v.boolean(),
+});
+
+/** PUT /v1/notification-settings のリクエストボディ。timing は重複不可、最大3件 (morning/afternoon/evening)。 */
+export const UpdateNotificationSettingsSchema = v.pipe(
+  v.array(_NotificationSettingItemSchema),
+  v.minLength(1, "通知設定は1件以上指定してください"),
+  v.maxLength(3, "通知設定は最大3件まで指定できます"),
+  v.check(
+    (items) => new Set(items.map((item) => item.timing)).size === items.length,
+    "timing が重複しています",
+  ),
+);
+
+export type UpdateNotificationSettingsInput = v.InferOutput<
+  typeof UpdateNotificationSettingsSchema
+>;

--- a/apps/api/src/services/notification-settings/index.ts
+++ b/apps/api/src/services/notification-settings/index.ts
@@ -3,3 +3,9 @@ export {
   type ListNotificationSettingsParams,
   type NotificationSettingItem,
 } from "./list.js";
+export {
+  updateNotificationSettings,
+  type UpdateNotificationSettingItem,
+  type UpdateNotificationSettingsParams,
+  type UpdateNotificationSettingsResult,
+} from "./update.js";

--- a/apps/api/src/services/notification-settings/update.test.ts
+++ b/apps/api/src/services/notification-settings/update.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Db } from "../../db/client.js";
+import { updateNotificationSettings } from "./update.js";
+
+const userId = "87d8b9c6-00e8-42aa-ae8c-7d0e83aa2fb7";
+
+const buildDb = (returnedRows: { id: string }[]) => {
+  const returning = vi.fn().mockResolvedValueOnce(returnedRows);
+  const onConflictDoUpdate = vi.fn(() => ({ returning }));
+  const values = vi.fn(() => ({ onConflictDoUpdate }));
+  const insert = vi.fn(() => ({ values }));
+  return {
+    db: { insert } as unknown as Db,
+    insert,
+    values,
+    onConflictDoUpdate,
+  };
+};
+
+describe("updateNotificationSettings", () => {
+  it("upserts all items and returns the count", async () => {
+    const { db, values, onConflictDoUpdate } = buildDb([
+      { id: "11111111-1111-1111-1111-111111111111" },
+      { id: "22222222-2222-2222-2222-222222222222" },
+      { id: "33333333-3333-3333-3333-333333333333" },
+    ]);
+
+    const result = await updateNotificationSettings(db, {
+      userId,
+      items: [
+        { timing: "morning", notifyTime: "07:30", isEnabled: true },
+        { timing: "afternoon", notifyTime: "12:00", isEnabled: false },
+        { timing: "evening", notifyTime: "21:00", isEnabled: true },
+      ],
+    });
+
+    expect(result).toEqual({ updated: 3 });
+    expect(values).toHaveBeenCalledWith([
+      { userId, timing: "morning", notifyTime: "07:30", isEnabled: true },
+      { userId, timing: "afternoon", notifyTime: "12:00", isEnabled: false },
+      { userId, timing: "evening", notifyTime: "21:00", isEnabled: true },
+    ]);
+    expect(onConflictDoUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the insert and returns 0 when items is empty", async () => {
+    const { db, insert } = buildDb([]);
+
+    const result = await updateNotificationSettings(db, { userId, items: [] });
+
+    expect(result).toEqual({ updated: 0 });
+    expect(insert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/notification-settings/update.ts
+++ b/apps/api/src/services/notification-settings/update.ts
@@ -19,8 +19,6 @@ export interface UpdateNotificationSettingsResult {
   updated: number;
 }
 
-const _excluded = (column: string) => sql.raw(`excluded."${column}"`);
-
 /**
  * 指定ユーザーの通知設定を timing 単位で upsert する。
  * 既存行があれば notify_time / is_enabled を更新し、無ければ新規作成する。
@@ -49,8 +47,8 @@ export const updateNotificationSettings = async (
     .onConflictDoUpdate({
       target: [notificationSettings.userId, notificationSettings.timing],
       set: {
-        notifyTime: _excluded("notify_time"),
-        isEnabled: _excluded("is_enabled"),
+        notifyTime: sql`excluded."notify_time"`,
+        isEnabled: sql`excluded."is_enabled"`,
         updatedAt: new Date(),
       },
     })

--- a/apps/api/src/services/notification-settings/update.ts
+++ b/apps/api/src/services/notification-settings/update.ts
@@ -1,0 +1,60 @@
+import { sql } from "drizzle-orm";
+
+import type { Db } from "../../db/client.js";
+import { notificationSettings } from "../../db/schema.js";
+import type { Timing } from "../../schemas/medicines/timing.js";
+
+export interface UpdateNotificationSettingItem {
+  timing: Timing;
+  notifyTime: string;
+  isEnabled: boolean;
+}
+
+export interface UpdateNotificationSettingsParams {
+  userId: string;
+  items: UpdateNotificationSettingItem[];
+}
+
+export interface UpdateNotificationSettingsResult {
+  updated: number;
+}
+
+const _excluded = (column: string) => sql.raw(`excluded."${column}"`);
+
+/**
+ * 指定ユーザーの通知設定を timing 単位で upsert する。
+ * 既存行があれば notify_time / is_enabled を更新し、無ければ新規作成する。
+ * @param db Drizzle クライアント
+ * @param params userId と更新対象の通知設定リスト (timing は一意)
+ * @returns upsert された件数
+ */
+export const updateNotificationSettings = async (
+  db: Db,
+  params: UpdateNotificationSettingsParams,
+): Promise<UpdateNotificationSettingsResult> => {
+  if (params.items.length === 0) {
+    return { updated: 0 };
+  }
+
+  const rows = params.items.map((item) => ({
+    userId: params.userId,
+    timing: item.timing,
+    notifyTime: item.notifyTime,
+    isEnabled: item.isEnabled,
+  }));
+
+  const inserted = await db
+    .insert(notificationSettings)
+    .values(rows)
+    .onConflictDoUpdate({
+      target: [notificationSettings.userId, notificationSettings.timing],
+      set: {
+        notifyTime: _excluded("notify_time"),
+        isEnabled: _excluded("is_enabled"),
+        updatedAt: new Date(),
+      },
+    })
+    .returning({ id: notificationSettings.id });
+
+  return { updated: inserted.length };
+};


### PR DESCRIPTION
## Summary
- 朝/昼/夕の通知設定を一括 upsert する `PUT /v1/notification-settings` を追加
- `(user_id, timing)` 一意制約を利用し、存在すれば `notify_time` / `is_enabled` を更新、無ければ新規作成
- レスポンスは upsert 件数 (`{ "updated": n }`)
- valibot スキーマで `timing` 重複・`notify_time` の HH:MM 形式・件数 (1〜3) を検証
- services / routes のテストと Bruno リクエストを追加

## Test plan
- [x] `pnpm --filter api test` (10 files, 26 tests passed)
- [x] `pnpm --filter api lint`
- [x] `pnpm --filter api fmt:check` 相当 (`pnpm fmt`)
- [x] `pnpm --filter api exec tsc --noEmit`
- [ ] Bruno で `PUT /api/v1/notification-settings` を実行し `{ "updated": 3 }` を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/riku10145/nonda/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->