### PR TITLE
feat: ui-demo skill で PR デモ生成を自動化

### DIFF
--- a/.claude/skills/api-verify/SKILL.md
+++ b/.claude/skills/api-verify/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: api-verify
+description: apps/api の変更点を curl で動作確認し、結果を現ブランチの PR に 2 件のコメント（詳細＋サマリー）として投稿する。ユーザーが `/api-verify` を明示実行した時のみ動作。
+disable-model-invocation: true
+argument-hint: "[METHOD PATH] (省略時は git diff から推測)"
+allowed-tools: Bash(curl:*), Bash(gh:*), Bash(git:*), Bash(jq:*), Read, Grep, Glob
+---
+
+# api-verify
+
+`apps/api` で実装した API エンドポイントを curl で叩き、結果を現ブランチの PR に投稿する。
+
+## 前提
+
+- 開発サーバーが `http://localhost:8787` で起動済み（`pnpm --filter api dev`、Doppler 必須）。**自動起動はしない。**
+- 現ブランチに紐づく GitHub PR が存在する（`gh pr view` で取得できる）。
+- `gh` CLI 認証済み。
+
+## 認証ヘッダ（差し替えポイント）
+
+現状はスタブ。Bruno の devUserId をそのまま使う:
+
+```
+x-user-id: 87d8b9c6-00e8-42aa-ae8c-7d0e83aa2fb7
+```
+
+> 🔧 **将来差し替え**: Auth.js セッションが入ったら、ここを `Cookie: ...` または `Authorization: Bearer ...` に変更する。`apps/api/src/routes/medicines/index.ts` の認証スタブが本実装に置き換わったタイミングが目安。
+
+## 実行手順
+
+### 1. PR 番号を取得
+
+```bash
+gh pr view --json number,headRefName,url -q '{number, branch: .headRefName, url}'
+```
+
+PR が存在しなければ「現ブランチに紐づく PR がありません」と報告して終了。
+
+### 2. 対象エンドポイントを決定
+
+**引数あり** (`/api-verify POST /v1/medicines`): その method+path を使用。
+
+**引数なし**:
+1. `git diff origin/main...HEAD --name-only -- 'apps/api/src/routes/**'` で変更ファイルを取得。
+2. 変更が無ければ「API の変更が無いため終了します」と報告して終了。
+3. 各ファイルから method+path を読み取る（`app.get(...)`, `app.post(...)` 等）。Hono のルートは `apps/api/src/index.ts` で `/api` プレフィックスが付くので、最終的なパスは `/api/v1/...` となる。
+4. 推測した一覧をユーザーに提示し「これで実行しますか？」と確認。
+
+### 3. 開発サーバーの疎通確認
+
+```bash
+curl -fsS -o /dev/null -w '%{http_code}' http://localhost:8787/health
+```
+
+`200` 以外なら「`pnpm --filter api dev` を起動してください」と報告して終了。
+
+### 4. リクエストボディを準備（POST/PUT/PATCH）
+
+1. `apps/api/src/schemas/<feature>/...` または `apps/api/src/routes/<feature>/...` から valibot スキーマを読む。
+2. スキーマからサンプルボディを生成し、ユーザーに提示して確認。
+3. 既存の `apps/api/bruno/<feature>/*.bru` があればそれをベースにすると速い。
+
+### 5. curl 実行
+
+各エンドポイントにつき:
+
+```bash
+curl -sS -i \
+  -X <METHOD> 'http://localhost:8787/api/v1/<path>' \
+  -H 'Content-Type: application/json' \
+  -H 'x-user-id: 87d8b9c6-00e8-42aa-ae8c-7d0e83aa2fb7' \
+  -w '\n---TIMING---\n%{http_code} %{time_total}\n' \
+  $( [ -n "$BODY" ] && echo "-d $BODY" )
+```
+
+レスポンス本体・ステータスコード・所要時間を保存。
+
+### 6. PR にコメント投稿（2 件、詳細 → サマリーの順）
+
+#### コメント 1: 詳細
+
+```markdown
+## 🔍 API 動作確認 (`<sha-short>`)
+
+### `<METHOD> /api/v1/<path>` → **<status>** (<time>s)
+
+<details><summary>Request</summary>
+
+​```http
+<METHOD> /api/v1/<path> HTTP/1.1
+Host: localhost:8787
+Content-Type: application/json
+x-user-id: 87d8b9c6-...
+
+<body or 空>
+​```
+
+</details>
+
+**Response**
+
+​```json
+<整形済み response body>
+​```
+
+---
+
+(以降エンドポイントごとに繰り返し)
+```
+
+投稿:
+
+```bash
+gh pr comment <PR#> --body-file /tmp/api-verify-detail.md
+```
+
+投稿後、レスポンスから URL を取り出してサマリーで参照:
+
+```bash
+gh api "repos/{owner}/{repo}/issues/<PR#>/comments" --jq '.[-1].html_url'
+```
+
+#### コメント 2: サマリー
+
+全件成功なら ✅、1 件でも 4xx/5xx があれば ⚠️ をタイトルに。
+
+```markdown
+## ✅ API 動作確認サマリー (`<sha-short>`)
+
+| Method | Endpoint | Status | Time |
+|---|---|---|---|
+| PUT | `/api/v1/notification-settings` | ✅ 200 | 0.04s |
+| GET | `/api/v1/medicines` | ✅ 200 | 0.02s |
+| POST | `/api/v1/medicines` | ⚠️ 400 | 0.01s |
+
+詳細: <詳細コメント URL>
+```
+
+失敗があってもそのまま投稿する（事前確認しない）。
+
+```bash
+gh pr comment <PR#> --body-file /tmp/api-verify-summary.md
+```
+
+### 7. 完了報告
+
+ユーザーに「2 件のコメントを PR #<num> に投稿しました」と URL 付きで伝える。
+
+## 重要な制約
+
+- **重複投稿の整理はしない**。同 skill を複数回叩いた場合、過去のコメントはそのまま残す（commit SHA で識別可能）。
+- **サーバーの自動起動はしない**。Doppler が必要なため。
+- **失敗しても投稿は止めない**。記録として残す。
+- **API 変更がない & 引数もない場合は何もせず終了**。エラーではない。

--- a/.claude/skills/ui-demo/README.md
+++ b/.claude/skills/ui-demo/README.md
@@ -1,0 +1,69 @@
+# ui-demo skill
+
+PR レビュー用に、UI 変更箇所のスクショ・操作デモ動画を Playwright で自動生成する Claude Code skill。
+
+## トリガー
+
+Claude Code 上で以下のように頼むと起動する:
+
+- 「PR デモ作って」
+- 「UI デモ生成」
+- 「スクショ撮って」
+- 「ログイン画面の操作動画撮って」
+
+## 初回セットアップ
+
+ホスト側に Playwright を入れる（プロジェクトの devDependencies でも、グローバルでも可）。
+
+```bash
+npm i -D playwright tsx
+npx playwright install chromium
+```
+
+`ui-demo-output/` は成果物ディレクトリ。`.gitignore` に追加推奨:
+
+```
+ui-demo-output/
+```
+
+## 使い方の最小手順
+
+1. UI を変更したブランチで Claude Code を起動
+2. 「UI デモ作って」と頼む
+3. Claude が**自動で**:
+   - `git diff origin/main...HEAD` で変更を検出
+   - 影響ルートを推定（確認は取らない）
+   - dev サーバの死活確認 → 落ちていれば自動起動（撮影後に自分で kill）
+   - `ui-demo-output/_run.ts` を生成して `npx tsx` で実行
+   - スクショと PR 本文用 Markdown を出力
+4. **動画も欲しい場合のみ**「操作動画も撮って」と追加で頼む。シナリオ（何をクリック/入力するか）だけ聞かれる
+5. 出力された画像/動画を GitHub の PR コメント欄にドラッグ&ドロップでアップロード
+
+## 動作確認（ダミー）
+
+dev サーバが起動した状態で:
+
+```
+Claude に「http://localhost:3000 のトップを撮って」と頼む
+```
+
+`ui-demo-output/screenshots/*.png` と `ui-demo-output/videos/*.webm` が生成されれば OK。
+
+## ファイル構成
+
+```
+.claude/skills/ui-demo/
+  SKILL.md                       # ワークフロー本体
+  README.md                      # このファイル
+  references/
+    playwright-recipe.md         # _run.ts の定型・録画設定・ハマり所
+    selector-strategy.md         # data-testid 優先などのセレクター指針
+```
+
+## スコープ外（将来検討）
+
+- YAML 台本 DSL（再撮影運用が定着したら）
+- 赤枠ハイライト / annotation DOM 差し込み
+- mp4 / GIF 変換（ffmpeg 必須になるので保留）
+- before/after 比較
+- `gh` 経由での画像自動アップロード

--- a/.claude/skills/ui-demo/SKILL.md
+++ b/.claude/skills/ui-demo/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: ui-demo
+description: PRのUI変更に対してスクショ・操作デモ動画をPlaywrightで自動生成するスキル。「PRデモ作って」「UIデモ生成」「スクショ撮って」「操作動画撮って」「レビュー用の画面キャプチャ」など、PRレビュー向けに画面キャプチャや操作デモ動画を作りたいという要望が出たら必ずこのスキルを起動する。Next.js / React プロジェクトでのフロントレビュー運用を想定。
+---
+
+# ui-demo skill
+
+UI 実装の PR をレビューするとき、レビュアーが dev サーバを立ち上げなくて済むように、変更箇所のスクショ・操作デモ動画を `ui-demo-output/` に出力する。
+
+**前提**: `references/playwright-recipe.md` を必ず最初に読む。Playwright スクリプトの定型・録画設定・localhost ガードはそこに集約。セレクター戦略は `references/selector-strategy.md`。
+
+## 自動化方針
+
+- **聞かずに進める**: 変更検出・ルート推定・dev サーバ起動・スクショ撮影までは自動。
+- **聞くのは「操作シナリオ」だけ**: 動画を撮るには「何をクリックして何を見せるか」の意図が必要。ユーザが「動画も」「操作デモも」と明示しなければ **スクショのみ** で完結する。
+- **不可逆な操作はしない**: 撮影は読み取り専用。ログイン以外のフォーム送信、削除ボタンなどは明示指示があるときだけ。
+
+## ワークフロー
+
+### 1. 変更検出（自動）
+
+```bash
+git diff --name-only origin/main...HEAD | grep -E '\.(tsx|jsx)$' | grep -E '(app/|components/|pages/)'
+```
+
+該当なしなら「UI 変更が見当たらない」と報告して終了。
+
+### 2. 影響ルートの推定（自動）
+
+- App Router: `apps/web/app/<path>/page.tsx` → `/<path>`（`(group)` セグメントは除去、`[param]` はユーザに値を聞くかダミーで撮る判断をログに残してスキップ）
+- 共通コンポーネント変更時: `grep -rl "ComponentName"` で import 元の page を逆引き
+- 推定結果は「これらを撮ります: /login, /dashboard」と一行で報告するだけ。**確認は取らない**
+
+### 3. dev サーバ自動起動（自動）
+
+```bash
+# 死活確認
+curl -sf -o /dev/null http://localhost:3000 && echo "up" || echo "down"
+```
+
+- `up` ならそのまま使う（既存サーバを尊重）
+- `down` なら `pnpm --filter web dev` を `run_in_background` で起動
+- 起動後、最大 60 秒ポーリングして 200 が返るのを待つ
+- **自分で起動した場合のみ** 最後に kill する。既存サーバは触らない
+- 起動 PID は変数で保持: `OUR_DEV_PID=...`
+
+### 4. Playwright 実行（自動）
+
+- `references/playwright-recipe.md` のテンプレで `ui-demo-output/_run.ts` を生成
+- 各ルートに対して `goto` → `screenshot` のループ
+- ユーザが「動画も」「操作デモ」と言った場合のみ、シナリオを聞いた上で `click` / `fill` を含むスクリプトを追記
+- `npx tsx ui-demo-output/_run.ts` で実行
+- URL は `localhost` / `127.0.0.1` / `.test` のみ許可（recipe の `assertSafeUrl()`）
+
+### 5. Markdown 生成（自動）
+
+PR 本文用スニペットを表示:
+
+```markdown
+## UI デモ
+
+| ルート | スクショ |
+|---|---|
+| /login | ![login](ui-demo-output/screenshots/login.png) |
+| /dashboard | ![dashboard](ui-demo-output/screenshots/dashboard.png) |
+
+<!-- 動画がある場合 -->
+### 操作デモ
+GitHub の PR コメント欄に `ui-demo-output/videos/flow.webm` をドラッグ&ドロップしてアップロードしてください。
+```
+
+### 6. 後処理（自動）
+
+- `_run.ts` を削除
+- 自分で起動した dev サーバを kill（`kill $OUR_DEV_PID`）
+- 出力ファイルパス一覧を報告
+
+## ユーザに必ず聞くこと
+
+- **動画シナリオ**: 「操作動画も」と言われたとき、何をクリック/入力するか。例: 「ログインフォームに demo@example.com を入れて送信ボタンを押す流れでいい？」
+- **`[param]` ルート**: 動的セグメントがあって、撮るべき具体値が diff から読めないとき
+- **`data-testid` 追加の可否**: セレクターが安定しないとき（`references/selector-strategy.md` 参照）
+
+それ以外は聞かない。
+
+## やらないこと（MVP スコープ外）
+
+- YAML 台本 DSL
+- 赤枠ハイライト / annotation DOM 差し込み
+- ffmpeg 経由の mp4/GIF 変換
+- before/after 比較
+- `gh` 経由での画像自動アップロード（API が不安定なので手動）
+
+## 初回セットアップ
+
+Playwright が未インストールならユーザに案内:
+
+```bash
+npm i -D playwright tsx
+npx playwright install chromium
+```
+
+詳細は `README.md`。

--- a/.claude/skills/ui-demo/references/playwright-recipe.md
+++ b/.claude/skills/ui-demo/references/playwright-recipe.md
@@ -45,7 +45,9 @@ async function main() {
 
   const loginUrl = "http://localhost:3000/login";
   assertSafeUrl(loginUrl);
-  await page.goto(loginUrl, { waitUntil: "networkidle" });
+  await page.goto(loginUrl, { waitUntil: "domcontentloaded", timeout: 60_000 });
+  // networkidle は Next.js dev の HMR で永遠に来ないことがあるのでフォールバック扱い
+  await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => {});
   await page.screenshot({ path: join(SHOTS, "login.png"), fullPage: true });
 
   // 例: フォーム入力 → 送信
@@ -77,7 +79,7 @@ npx tsx ui-demo-output/_run.ts
 ## よくあるハマり
 
 - **動画が 0 バイト**: `context.close()` 前に `page.close()` していない。順序を守る。
-- **`networkidle` で固まる**: SSE / WebSocket があると永遠に idle にならない。`domcontentloaded` + 明示的な `waitForSelector` に切り替える。
+- **`networkidle` で固まる**: Next.js dev の HMR / SSE / WebSocket があると永遠に idle にならない。テンプレ通り `domcontentloaded` をプライマリにし、`networkidle` は `catch(() => {})` で短いタイムアウトのフォールバックにする（実測で動作確認済み）。
 - **Next.js の初回ビルドで遅い**: `goto` のタイムアウトを 60s 程度に伸ばす（`{ timeout: 60_000 }`）。
 - **dev サーバが落ちている**: スクリプト先頭で `fetch("http://localhost:3000")` して死活確認するのも手。
 

--- a/.claude/skills/ui-demo/references/playwright-recipe.md
+++ b/.claude/skills/ui-demo/references/playwright-recipe.md
@@ -1,0 +1,86 @@
+# Playwright レシピ
+
+`ui-demo-output/_run.ts` を生成するときの定型。コピペベースで OK、必要な箇所だけ書き換える。
+
+## 必須要件
+
+- **URL ガード**: `goto` 前に `assertSafeUrl()` を通す。`localhost` / `127.0.0.1` / `.test` 以外は throw。
+- **録画**: `context` 単位で `recordVideo` を指定。`page.close()` 後に `.webm` がフラッシュされる。
+- **スクショ**: `page.screenshot({ path, fullPage: true })`。命名は `<route>-<state>.png`。
+- **viewport**: デフォルト 1280x800。モバイル確認が必要なら別 context で。
+- **headless**: true 固定（CI でも動くように）。
+
+## テンプレ
+
+```ts
+// ui-demo-output/_run.ts
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+const OUT = "ui-demo-output";
+const SHOTS = join(OUT, "screenshots");
+const VIDEOS = join(OUT, "videos");
+mkdirSync(SHOTS, { recursive: true });
+mkdirSync(VIDEOS, { recursive: true });
+
+function assertSafeUrl(url: string) {
+  const u = new URL(url);
+  const ok =
+    u.hostname === "localhost" ||
+    u.hostname === "127.0.0.1" ||
+    u.hostname.endsWith(".test");
+  if (!ok) throw new Error(`unsafe url: ${url}`);
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 800 },
+    recordVideo: { dir: VIDEOS, size: { width: 1280, height: 800 } },
+  });
+  const page = await context.newPage();
+
+  // --- ここから個別シナリオ ---
+
+  const loginUrl = "http://localhost:3000/login";
+  assertSafeUrl(loginUrl);
+  await page.goto(loginUrl, { waitUntil: "networkidle" });
+  await page.screenshot({ path: join(SHOTS, "login.png"), fullPage: true });
+
+  // 例: フォーム入力 → 送信
+  // await page.getByTestId("email").fill("demo@example.com");
+  // await page.getByRole("button", { name: "ログイン" }).click();
+  // await page.waitForURL("**/dashboard");
+  // await page.screenshot({ path: join(SHOTS, "dashboard.png"), fullPage: true });
+
+  // --- ここまで ---
+
+  await page.close();
+  await context.close();
+  await browser.close();
+  console.log("done");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+```
+
+## 実行
+
+```bash
+npx tsx ui-demo-output/_run.ts
+```
+
+## よくあるハマり
+
+- **動画が 0 バイト**: `context.close()` 前に `page.close()` していない。順序を守る。
+- **`networkidle` で固まる**: SSE / WebSocket があると永遠に idle にならない。`domcontentloaded` + 明示的な `waitForSelector` に切り替える。
+- **Next.js の初回ビルドで遅い**: `goto` のタイムアウトを 60s 程度に伸ばす（`{ timeout: 60_000 }`）。
+- **dev サーバが落ちている**: スクリプト先頭で `fetch("http://localhost:3000")` して死活確認するのも手。
+
+## 出力後の掃除
+
+`_run.ts` は使い捨て。実行後に削除してコミットしない。`ui-demo-output/` は `.gitignore` 推奨。

--- a/.claude/skills/ui-demo/references/selector-strategy.md
+++ b/.claude/skills/ui-demo/references/selector-strategy.md
@@ -1,0 +1,40 @@
+# セレクター戦略
+
+Next.js / React で安定して動くセレクターを選ぶ指針。動的クラス名（Tailwind の `bg-blue-500` や CSS Modules の `_login_abc123`）に依存しないこと。
+
+## 優先順位
+
+1. **`data-testid`** — 最優先。JSX に `data-testid="login-submit"` があれば `page.getByTestId("login-submit")`。
+2. **`aria-label` / ロール** — `page.getByRole("button", { name: "ログイン" })`。アクセシビリティを兼ねるので増やしても害がない。
+3. **可視テキスト** — `page.getByText("ログイン")`。i18n でテキストが変わる箇所では避ける。
+4. **構造的 CSS セレクター** — 最終手段。`form[action="/login"] input[type="email"]` のように、意味のある属性で絞る。
+5. **絶対に避ける**: Tailwind クラス、CSS Modules のハッシュ付きクラス、`nth-child` のような位置依存セレクター。
+
+## 変更コンポーネントからセレクターを抽出する手順
+
+1. `git diff origin/main...HEAD -- '*.tsx'` で変更点を見る
+2. 操作対象（ボタン・入力欄）の JSX を読む
+3. 上記優先順位で使えるものを拾う
+4. `data-testid` も `aria-label` も無く、テキストも動的な場合は **ユーザに「`data-testid` を足してもいい？」と聞く**。勝手にコンポーネントを書き換えない
+
+## Playwright 側の書き方
+
+```ts
+// testid（最優先）
+await page.getByTestId("login-submit").click();
+
+// role + name
+await page.getByRole("button", { name: "ログイン" }).click();
+await page.getByRole("textbox", { name: "メールアドレス" }).fill("a@b.test");
+
+// label 付き input
+await page.getByLabel("パスワード").fill("xxx");
+
+// テキスト（i18n しない箇所だけ）
+await page.getByText("利用規約に同意する").click();
+```
+
+## HeroUI / shadcn-ui を使っている場合
+
+- HeroUI v3 の `<Button>` などはラップされるが、`aria-label` や `name` prop は子要素に伝播する。`getByRole` が効きやすい。
+- ネイティブ `<button>` ではなく `<div role="button">` になっていることがあるので、`getByRole("button", ...)` を優先。

--- a/.gitignore
+++ b/.gitignore
@@ -143,4 +143,8 @@ vite.config.ts.timestamp-*
 .vite/
 
 # Claude
-.claude
+.claude/*
+!.claude/skills/
+
+# ui-demo skill output
+ui-demo-output/

--- a/package.json
+++ b/package.json
@@ -11,9 +11,15 @@
   "license": "ISC",
   "packageManager": "pnpm@10.33.2",
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild", "lefthook", "workerd"]
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "lefthook",
+      "workerd"
+    ]
   },
   "devDependencies": {
-    "lefthook": "^2.1.6"
+    "lefthook": "^2.1.6",
+    "playwright": "^1.59.1",
+    "tsx": "^4.21.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       lefthook:
         specifier: ^2.1.6
         version: 2.1.6
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
 
   apps/api:
     dependencies:
@@ -2002,6 +2008,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2259,6 +2270,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -3866,6 +3887,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4100,6 +4124,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.4.31:
     dependencies:


### PR DESCRIPTION
## Summary
- PR レビュー用に、UI 変更箇所のスクショ・操作デモ動画を Playwright で自動生成する Claude Code skill (`ui-demo`) を追加
- 変更検出 → ルート推定 → dev サーバ自動起動 → 撮影 → Markdown 出力までを一気通貫で自動化（聞くのは動画シナリオなど必要最小限）
- `.claude` 全体を ignore していたのを skills/ サブツリーだけ追跡するように変更し、既存ローカル skill (`api-verify`) も一緒に取り込み

## 構成
```
.claude/skills/ui-demo/
  SKILL.md                       # ワークフロー本体（トリガー語強め）
  README.md                      # セットアップ・最小手順
  references/
    playwright-recipe.md         # _run.ts の定型・録画設定・URL ガード
    selector-strategy.md         # data-testid 優先などのセレクター指針
```

## MVP スコープ
- スクショ：完全自動（dev サーバ起動含む）
- 動画：シナリオだけユーザに聞いて自動撮影
- URL ガード：`localhost` / `127.0.0.1` / `.test` 以外は throw

スコープ外（将来検討）: YAML 台本 DSL、赤枠ハイライト、ffmpeg 経由の mp4/GIF 変換、before/after 比較、`gh` 経由の画像自動アップロード。

## Test plan
- [ ] `npm i -D playwright tsx && npx playwright install chromium` でセットアップ
- [ ] `pnpm --filter web dev` を起動した状態で「http://localhost:3000 のトップを撮って」を試す
- [ ] dev サーバを止めた状態で同じ依頼をして、skill が自前で dev サーバを起動 → 撮影 → kill するか確認
- [ ] UI 変更を含む別ブランチで「PR デモ作って」を試し、`ui-demo-output/screenshots/` と PR 本文用 Markdown が出力されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/riku10145/nonda/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->