### PR TITLE
feat(web): 認証必須エリアの共通レイアウトを追加

### DIFF
--- a/apps/web/app/(authed)/_components/header/header.tsx
+++ b/apps/web/app/(authed)/_components/header/header.tsx
@@ -1,0 +1,18 @@
+import { auth } from "@/auth";
+
+import { LogoutButton } from "./logout-button";
+
+export async function Header() {
+  const session = await auth();
+  const name = session?.user?.name ?? "";
+
+  return (
+    <header className="flex items-center justify-between border-b border-gray-200 px-6 py-3">
+      <h1 className="text-lg font-bold">nonda</h1>
+      <div className="flex items-center gap-3">
+        {name && <span className="text-sm text-gray-700">{name}</span>}
+        <LogoutButton />
+      </div>
+    </header>
+  );
+}

--- a/apps/web/app/(authed)/_components/header/index.tsx
+++ b/apps/web/app/(authed)/_components/header/index.tsx
@@ -1,0 +1,1 @@
+export { Header } from "./header";

--- a/apps/web/app/(authed)/_components/header/logout-button.tsx
+++ b/apps/web/app/(authed)/_components/header/logout-button.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { Button } from "@heroui/react";
+import { signOut } from "next-auth/react";
+
+export function LogoutButton() {
+  return (
+    <Button size="sm" variant="tertiary" onPress={() => signOut({ redirectTo: "/login" })}>
+      ログアウト
+    </Button>
+  );
+}

--- a/apps/web/app/(authed)/layout.tsx
+++ b/apps/web/app/(authed)/layout.tsx
@@ -1,0 +1,10 @@
+import { Header } from "./_components/header";
+
+export default function AuthedLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-dvh flex-col">
+      <Header />
+      <main className="flex-1">{children}</main>
+    </div>
+  );
+}

--- a/apps/web/app/(authed)/page.tsx
+++ b/apps/web/app/(authed)/page.tsx
@@ -1,0 +1,11 @@
+import { verifySession } from "@/lib/auth-guard";
+
+export default async function Home() {
+  await verifySession();
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold">Nonda</h1>
+    </div>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,7 +1,0 @@
-export default function Home() {
-  return (
-    <main className="p-6">
-      <h1 className="text-2xl font-bold">Nonda</h1>
-    </main>
-  );
-}

--- a/apps/web/lib/auth-guard.ts
+++ b/apps/web/lib/auth-guard.ts
@@ -1,0 +1,13 @@
+import "server-only";
+
+import { redirect } from "next/navigation";
+
+import { auth } from "@/auth";
+
+export async function verifySession() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+  return session;
+}


### PR DESCRIPTION
## Summary
- `(authed)` Route Group を作成し、ヘッダー付き共通レイアウトを適用
- ヘッダーは Server Component で `auth()` からユーザー情報を取得、ログアウトボタンのみ Client Component に切り出す（Composition パターン）
- `verifySession()` ヘルパを `lib/auth-guard.ts` に追加し、各 `page.tsx` 冒頭で呼ぶ多層防御パターンを採用
- 認可ロジックは layout に置かない（『Next.jsの考え方』 part_5_auth の指針に従う）
- `/login` には共通レイアウトを適用しない

## 『Next.jsの考え方』から参考にした点

### 1. 認可ロジックを Layout に置かない（[part_5_auth](https://zenn.dev/akfm/books/nextjs-basic-principle/viewer/part_5_auth)）
> ページとレイアウトは並行にレンダリングされるため、必ずしもレイアウト層に実装した認可チェックがページより先に実行されるとは限りません。

- `(authed)/layout.tsx` にはヘッダー UI のみを置く
- 認可は `(authed)/page.tsx` 冒頭で `verifySession()` を呼ぶ形に

### 2. データアクセス認可をフェッチ層に持たせる（[part_5_auth](https://zenn.dev/akfm/books/nextjs-basic-principle/viewer/part_5_auth)）
> データアクセス認可が必要な場合は、分離したデータフェッチ層で実装しましょう。

- 既存の `lib/api-client.ts` が未ログイン時に `ApiError(401)` を投げる構造を踏襲
- `verifySession()` と組み合わせて多層防御を構成

### 3. Composition パターン（[part_2_composition_pattern](https://zenn.dev/akfm/books/nextjs-basic-principle/viewer/part_2_composition_pattern)）
> `"use client"` を上位に置かず、Client Components はコンポーネントツリーの末端に分離する。

- `Header` は Server Component（`auth()` 呼び出し可能）のまま保持
- `LogoutButton` のみ `"use client"` に切り出して末端配置

### 今回の PR では適用していない章
- **Container/Presentational パターン**：データ取得を伴うコンポーネントが今回無いため未適用。次の機能実装時に `_containers/<name>/` 構造で導入予定
- **データフェッチコロケーション / Request Memoization**：同上
- **`error.tsx` / `loading.tsx`**：共通レイアウトの範囲外のため次回以降

## Test plan
- [ ] `/` にアクセスしてヘッダー（左に「nonda」/ 右にユーザー名 + ログアウトボタン）が表示される
- [ ] ログアウトボタンを押すと `/login` に遷移する
- [ ] 未ログインで `/` を叩いたら `/login` にリダイレクトされる
- [ ] `/login` ではヘッダーが表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)