### PR TITLE
chore(lefthook): fmt glob に json を追加して drizzle/meta/*.json も pre-commit で整形する

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,7 +2,7 @@ pre-commit:
   jobs:
     - name: web-fmt
       root: apps/web
-      glob: "*.{js,ts,jsx,tsx,css,md}"
+      glob: "*.{js,ts,jsx,tsx,css,json,md}"
       run: pnpm exec oxfmt {staged_files}
       stage_fixed: true
 
@@ -13,7 +13,7 @@ pre-commit:
 
     - name: api-fmt
       root: apps/api
-      glob: "*.{js,ts,md}"
+      glob: "*.{js,ts,json,md}"
       run: pnpm exec oxfmt {staged_files}
       stage_fixed: true
 


### PR DESCRIPTION
closes #51

## 背景

`drizzle-kit generate` が生成する `apps/api/drizzle/meta/*.json` が pre-commit を素通りして CI の `fmt:check` で初めて落ちる事象が発生していた（直前の修正コミット a370b24）。

原因は `lefthook.yml` の fmt job の glob が `*.{js,ts,md}` (web は `+jsx,tsx,css`) のみで JSON が対象外だったため。`pnpm fmt`（= `oxfmt .`）は JSON も整形対象に含むので、ローカル全量実行と pre-commit のカバレッジが食い違っていた。

## 変更

`lefthook.yml` の fmt job の glob に `json` を追加。

| job | before | after |
| --- | --- | --- |
| `web-fmt` | `*.{js,ts,jsx,tsx,css,md}` | `*.{js,ts,jsx,tsx,css,json,md}` |
| `api-fmt` | `*.{js,ts,md}` | `*.{js,ts,json,md}` |

`stage_fixed: true` は既存設定のままなので、ステージ済み JSON の整形差分は同コミットに取り込まれる。

## 動作確認

- `apps/api` で `pnpm exec oxfmt --check drizzle/meta/_journal.json drizzle/meta/0005_snapshot.json package.json` → すべて整形済み（差分なし）であることを確認
- `pnpm-lock.yaml` は YAML のため glob にマッチせず、無駄な実行は発生しない
- `package.json` は `*.{...,json,...}` で拾われるためローカル/CI で揺れが起きない

## 対応範囲外（フォロー候補）

issue #51 の確認事項に挙がっていたルート直下 (`./package.json`) と `packages/db/*.json` は、現状 web/api 限定ジョブの対象外。今回は issue 本文の提案範囲（既存 2 ジョブへの `json` 追加）に絞った最小変更とし、必要になった時点で別ジョブ追加で対応する方針。

## Test plan

- [ ] `apps/api/drizzle/meta/*.json` を意図的に崩した状態でステージ → `git commit` で `api-fmt` が走り、整形差分が同コミットに含まれることを確認
- [ ] `apps/web` 配下の `*.json` を編集してステージ → `web-fmt` が走ることを確認
- [ ] CI の `fmt:check` がグリーンであること