### PR TITLE
feat(web): add shared side menu via AppShell for authed routes

### DIFF
--- a/apps/web/app/(authed)/_shell.tsx
+++ b/apps/web/app/(authed)/_shell.tsx
@@ -45,6 +45,7 @@ export function Shell({ children }: { children: React.ReactNode }) {
             href={item.href}
             label={item.label}
             active={pathname === item.href}
+            onClick={() => mobileOpened && toggleMobile()}
           />
         ))}
       </AppShell.Navbar>

--- a/apps/web/app/(authed)/_shell.tsx
+++ b/apps/web/app/(authed)/_shell.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { AppShell, Burger, Group, NavLink, Text } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+interface MenuItem {
+  label: string;
+  href: string;
+}
+
+const _menuItems: MenuItem[] = [{ label: "ホーム", href: "/" }];
+
+export function Shell({ children }: { children: React.ReactNode }) {
+  const [mobileOpened, { toggle: toggleMobile }] = useDisclosure();
+  const [desktopOpened, { toggle: toggleDesktop }] = useDisclosure(true);
+  const pathname = usePathname();
+
+  return (
+    <AppShell
+      header={{ height: 60 }}
+      navbar={{
+        width: 260,
+        breakpoint: "sm",
+        collapsed: { mobile: !mobileOpened, desktop: !desktopOpened },
+      }}
+      padding="md"
+    >
+      <AppShell.Header>
+        <Group h="100%" px="md">
+          <Burger opened={mobileOpened} onClick={toggleMobile} hiddenFrom="sm" size="sm" />
+          <Burger opened={desktopOpened} onClick={toggleDesktop} visibleFrom="sm" size="sm" />
+          <Text size="lg" fw={700}>
+            Nonda
+          </Text>
+        </Group>
+      </AppShell.Header>
+
+      <AppShell.Navbar p="md">
+        {_menuItems.map((item) => (
+          <NavLink
+            key={item.href}
+            component={Link}
+            href={item.href}
+            label={item.label}
+            active={pathname === item.href}
+          />
+        ))}
+      </AppShell.Navbar>
+
+      <AppShell.Main>{children}</AppShell.Main>
+    </AppShell>
+  );
+}

--- a/apps/web/app/(authed)/layout.tsx
+++ b/apps/web/app/(authed)/layout.tsx
@@ -1,0 +1,5 @@
+import { Shell } from "./_shell";
+
+export default function AuthedLayout({ children }: { children: React.ReactNode }) {
+  return <Shell>{children}</Shell>;
+}

--- a/apps/web/app/(authed)/page.tsx
+++ b/apps/web/app/(authed)/page.tsx
@@ -1,13 +1,9 @@
-import { Box, Title } from "@mantine/core";
+import { Title } from "@mantine/core";
 
 import { verifySession } from "@/lib/auth-guard";
 
 export default async function Home() {
   await verifySession();
 
-  return (
-    <Box p="lg">
-      <Title order={1}>Nonda</Title>
-    </Box>
-  );
+  return <Title order={1}>Nonda</Title>;
 }


### PR DESCRIPTION
(authed) ルートグループに layout.tsx を追加し、Mantine AppShell で
ヘッダー + サイドメニュー（Navbar）を全認証ページ共通で適用。
モバイルは Burger で開閉、デスクトップは常時表示で折りたたみ可。

https://claude.ai/code/session_01N4cX3BGFEs34KMp9dL9pnE
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/riku10145/nonda/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->