### PR TITLE
docs: update README to reflect Mantine and correct api dev port

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ nonda/
 
 | | 技術 |
 |---|---|
-| フロントエンド | Next.js 16 (App Router), TypeScript, Tailwind CSS v4 |
+| フロントエンド | Next.js 16 (App Router), TypeScript, Mantine |
 | バックエンド | Hono, TypeScript, Node.js |
 | パッケージ管理 | pnpm |
 | Linter | oxlint |
@@ -36,6 +36,6 @@ pnpm install
 # web (localhost:3000)
 pnpm --filter web dev
 
-# api (localhost:8080)
+# api (localhost:8787)
 pnpm --filter api dev
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ nonda/
 | | 技術 |
 |---|---|
 | フロントエンド | Next.js 16 (App Router), TypeScript, Mantine |
-| バックエンド | Hono, TypeScript, Node.js |
+| バックエンド | Hono, TypeScript, Cloudflare Workers |
 | パッケージ管理 | pnpm |
 | Linter | oxlint |
 | Formatter | oxfmt |


### PR DESCRIPTION
- Replace Tailwind CSS v4 with Mantine in the tech stack table
- Fix api dev server port (8080 -> 8787) to match wrangler default

https://claude.ai/code/session_0183U6faz4UB5WdGYBTRqgUi
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/riku10145/nonda/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->